### PR TITLE
Allow unreferenced images shipped with the game to be used

### DIFF
--- a/mods/core/unused_images.rpy
+++ b/mods/core/unused_images.rpy
@@ -1,0 +1,110 @@
+image remy normal d = "cr/remy_normal_d.png"
+image bryce sad old flip = "cr/bryce_sad_old_flip.png"
+image maverick laugh d = "cr/maverick_laugh_d.png"
+image maverick scared c = "cr/maverick_scared_c.png"
+image zhong normal bx = "cr/zhong_normal_bx.png"
+image miles bite b = "cr/miles_bite_b.png"
+image maverick normal d = "cr/maverick_normal_d.png"
+image anna sad d = "cr/anna_sad_d.png"
+image remy angry d = "cr/remy_angry_d.png"
+image remy sad d = "cr/remy_sad_d.png"
+image maverick scared d = "cr/maverick_scared_d.png"
+image bryce stern old flip = "cr/bryce_stern_old_flip.png"
+image bryce angry old b = "cr/bryce_angry_old_b.png"
+image miles angry b = "cr/miles_angry_b.png"
+image anna normal d = "cr/anna_normal_d.png"
+image remy look d = "cr/remy_look_d.png"
+image maverick angry d = "cr/maverick_angry_d.png"
+image bryce sad flip = "cr/bryce_sad_flip.png"
+image bryce flirty old flip = "cr/bryce_flirty_old_flip.png"
+image maverick nice d = "cr/maverick_nice_d.png"
+image miles growl b = "cr/miles_growl_b.png"
+image anna smirk d = "cr/anna_smirk_d.png"
+image anna disgust d = "cr/anna_disgust_d.png"
+image bryce brow old flip = "cr/bryce_brow_old_flip.png"
+image remy smile d = "cr/remy_smile_d.png"
+image remy shy d = "cr/remy_shy_d.png"
+image maverick laugh b = "cr/maverick_laugh_b.png"
+image maverick laugh c = "cr/maverick_laugh_c.png"
+image bryce sad b old flip = "cr/bryce_sad_b_old_flip.png"
+image bryce angry old flip = "cr/bryce_angry_old_flip.png"
+image miles bite2 b = "cr/miles_bite2_b.png"
+image bryce sad b old = "cr/bryce_sad_b_old.png"
+image bryce angry old b flip = "cr/bryce_angry_old_b_flip.png"
+image zhong normal cx = "cr/zhong_normal_cx.png"
+image bryce normal old flip = "cr/bryce_normal_old_flip.png"
+image anna face d = "cr/anna_face_d.png"
+image bryce laugh old flip = "cr/bryce_laugh_old_flip.png"
+image anna rage d = "cr/anna_rage_d.png"
+image bryce smirk old flip = "cr/bryce_smirk_old_flip.png"
+image remy look dk flip = im.Flip(im.Recolor("cr/remy_look.png", 80, 80, 100, 255), horizontal=True)
+image zhong normal bx flip = im.Flip("cr/zhong_normal_bx.png", horizontal=True)
+image remy normal dk flip = im.Flip(im.Recolor("cr/remy_normal.png", 80, 80, 100, 255), horizontal=True)
+image maverick normal b flip = im.Flip("cr/maverick_normal_b.png", horizontal=True)
+image maverick normal d flip = im.Flip("cr/maverick_normal_d.png", horizontal=True)
+image bryce stern b dk flip = im.Flip(im.Recolor("cr/bryce_stern_b.png", 70, 70, 100, 255), horizontal=True)
+image katsu excited dk flip = im.Flip(im.Recolor("cr/katsu_excited.png", 80, 80, 100, 255), horizontal=True)
+image remy smile dk flip = im.Flip(im.Recolor("cr/remy_smile.png", 80, 80, 100, 255), horizontal=True)
+image anna sad c flip = im.Flip("cr/anna_sad_c.png", horizontal=True)
+image maverick scared flip = im.Flip("cr/maverick_scared.png", horizontal=True)
+image anna sad d flip = im.Flip("cr/anna_sad_d.png", horizontal=True)
+image bryce normal b dk flip = im.Flip(im.Recolor("cr/bryce_normal_b.png", 70, 70, 100, 255), horizontal=True)
+image damion arrogant flip = im.Flip("cr/damion_arrogant.png", horizontal=True)
+image bryce normal dk flip = im.Flip(im.Recolor("cr/bryce_normal.png", 70, 70, 100, 255), horizontal=True)
+image reza gunpoint dk flip = im.Flip(im.Recolor("cr/reza_gunpoint.png", 70, 70, 100, 255), horizontal=True)
+image bryce smirk b dk flip = im.Flip(im.Recolor("cr/bryce_smirk_b.png", 70, 70, 100, 255), horizontal=True)
+image anna disgust d flip = im.Flip("cr/anna_disgust_d.png", horizontal=True)
+image bryce stern dk flip = im.Flip(im.Recolor("cr/bryce_stern.png", 70, 70, 100, 255), horizontal=True)
+image maverick nice d flip = im.Flip("cr/maverick_nice_d.png", horizontal=True)
+image remy angry d flip = im.Flip("cr/remy_angry_d.png", horizontal=True)
+image bryce brow b dk flip = im.Flip(im.Recolor("cr/bryce_brow_b.png", 70, 70, 100, 255), horizontal=True)
+image zhong normal cx flip = im.Flip("cr/zhong_normal_cx.png", horizontal=True)
+image miles bite2 flip = im.Flip("cr/miles_bite2.png", horizontal=True)
+image maverick nice b flip = im.Flip("cr/maverick_nice_b.png", horizontal=True)
+image miles angry b flip = im.Flip("cr/miles_angry_b.png", horizontal=True)
+image remy angry dk flip = im.Flip(im.Recolor("cr/remy_angry.png", 80, 80, 100, 255), horizontal=True)
+image katsu exhausted dk flip = im.Flip(im.Recolor("cr/katsu_exhausted.png", 80, 80, 100, 255), horizontal=True)
+image maverick angry dk flip = im.Flip(im.Recolor("cr/maverick_angry.png", 70, 70, 100, 255), horizontal=True)
+image anna face c flip = im.Flip("cr/anna_face_c.png", horizontal=True)
+image reza normal2 flip = im.Flip("cr/reza_normal2.png", horizontal=True)
+image anna rage d flip = im.Flip("cr/anna_rage_d.png", horizontal=True)
+image reza normalx flip = im.Flip("cr/reza_normalx.png", horizontal=True)
+image bryce brow dk flip = im.Flip(im.Recolor("cr/bryce_brow.png", 70, 70, 100, 255), horizontal=True)
+image reza normal dk flip = im.Flip(im.Recolor("cr/reza_normal.png", 70, 70, 100, 255), horizontal=True)
+image damion normal flip = im.Flip("cr/damion_normal.png", horizontal=True)
+image remy shy d flip = im.Flip("cr/remy_shy_d.png", horizontal=True)
+image remy shy dk flip = im.Flip(im.Recolor("cr/remy_shy.png", 80, 80, 100, 255), horizontal=True)
+image maverick angry d flip = im.Flip("cr/maverick_angry_d.png", horizontal=True)
+image maverick angry b flip = im.Flip("cr/maverick_angry_b.png", horizontal=True)
+image anna smirk d flip = im.Flip("cr/anna_smirk_d.png", horizontal=True)
+image anna smirk c flip = im.Flip("cr/anna_smirk_c.png", horizontal=True)
+image remy sad dk flip = im.Flip(im.Recolor("cr/remy_sad.png", 80, 80, 100, 255), horizontal=True)
+image bryce smirk dk flip = im.Flip(im.Recolor("cr/bryce_smirk.png", 70, 70, 100, 255), horizontal=True)
+image reza angry dk flip = im.Flip(im.Recolor("cr/reza_angry.png", 70, 70, 100, 255), horizontal=True)
+image remy normal d flip = im.Flip("cr/remy_normal_d.png", horizontal=True)
+image miles growl b flip = im.Flip("cr/miles_growl_b.png", horizontal=True)
+image damion face flip = im.Flip("cr/damion_face.png", horizontal=True)
+image remy smile d flip = im.Flip("cr/remy_smile_d.png", horizontal=True)
+image bryce flirty b dk flip = im.Flip(im.Recolor("cr/bryce_flirty_b.png", 70, 70, 100, 255), horizontal=True)
+image miles bite2 b flip = im.Flip("cr/miles_bite2_b.png", horizontal=True)
+image anna face d flip = im.Flip("cr/anna_face_d.png", horizontal=True)
+image maverick scared b flip = im.Flip("cr/maverick_scared_b.png", horizontal=True)
+image maverick scared c flip = im.Flip("cr/maverick_scared_c.png", horizontal=True)
+image maverick scared d flip = im.Flip("cr/maverick_scared_d.png", horizontal=True)
+image remy sad d flip = im.Flip("cr/remy_sad_d.png", horizontal=True)
+image bryce sad b flip = im.Flip("cr/bryce_sad_b.png", horizontal=True)
+image maverick laugh c flip = im.Flip("cr/maverick_laugh_c.png", horizontal=True)
+image miles bite b flip = im.Flip("cr/miles_bite_b.png", horizontal=True)
+image maverick laugh d flip = im.Flip("cr/maverick_laugh_d.png", horizontal=True)
+image maverick laugh b flip = im.Flip("cr/maverick_laugh_b.png", horizontal=True)
+image bryce laugh b dk flip = im.Flip(im.Recolor("cr/bryce_laugh_b.png", 70, 70, 100, 255), horizontal=True)
+image anna disgust c flip = im.Flip("cr/anna_disgust_c.png", horizontal=True)
+image bryce laugh dk flip = im.Flip(im.Recolor("cr/bryce_laugh.png", 70, 70, 100, 255), horizontal=True)
+image anna rage c flip = im.Flip("cr/anna_rage_c.png", horizontal=True)
+image anna normal d flip = im.Flip("cr/anna_normal_d.png", horizontal=True)
+image maverick normal dk flip = im.Flip(im.Recolor("cr/maverick_normal.png", 70, 70, 100, 255), horizontal=True)
+image bryce flirty dk flip = im.Flip(im.Recolor("cr/bryce_flirty.png", 70, 70, 100, 255), horizontal=True)
+image katsu normal dk flip = im.Flip(im.Recolor("cr/katsu_normal.png", 80, 80, 100, 255), horizontal=True)
+image anna normal c flip = im.Flip("cr/anna_normal_c.png", horizontal=True)
+image katsu smile dk flip = im.Flip(im.Recolor("cr/katsu_smile.png", 80, 80, 100, 255), horizontal=True)
+image remy look d flip = im.Flip("cr/remy_look_d.png", horizontal=True)


### PR DESCRIPTION
Added a file containing unused flipped sprites for ones defined without one.
Added definitions for undeclared sprites

Note this does not include grayscale nor sepia versions of images