### PR TITLE
mod_load functions will now be called after all mods are imported

### DIFF
--- a/modloader/__init__.py
+++ b/modloader/__init__.py
@@ -147,7 +147,7 @@ def main(reload_mods=False):
         if os.path.isdir(resource_dir):
             renpy.config.searchpath.append(resource_dir)
 
-        print "Begin mod load: {}".format(mod)
+        print "Begin mod import: {}".format(mod)
 
         # Try importing the mod.
         # Note: This doesn't give my mod functionality. To give the mod
@@ -155,7 +155,12 @@ def main(reload_mods=False):
         mod_object = importlib.import_module(mod)
         if reload_mods:
             rreload(mod_object, modules)
-
+    
+    # After all mods are imported, call their respective mod_load functions
+    for mod_name, mod in modinfo.get_mods().iteritems():
+        print "Loading mod {}".format(mod_name)
+        mod.mod_load()
+    
     # After all mods are loaded, call their respective mod_complete functions
     for mod_name, mod in modinfo.get_mods().iteritems():
         print "Completing mod {}".format(mod_name)

--- a/modloader/modclass.py
+++ b/modloader/modclass.py
@@ -48,6 +48,5 @@ def loadable_mod(modclass):
         raise Exception("Class must be a subclass of Mod")
 
     mod = modclass()
-    mod.mod_load()
 
     modinfo.add_mod(mod.mod_info()[0], mod)


### PR DESCRIPTION
This changes the mod loading in a way, that mod_load function isn't called right after the mod is imported anymore. All mod_load functions are called one by one only after all the mods are loaded and added to the modlist.

It allows mods to see the complete modlist from their mod_load functions and not just a part of it like before.