### PR TITLE
Fixed: hooks not being chained properly behind If nodes

### DIFF
--- a/modloader/modast.py
+++ b/modloader/modast.py
@@ -479,7 +479,7 @@ def hook_opcode(node, func):
     # The tuple is in the format (filename, filenumber)
     # This is used by the renpy stacktrace
     hook = ASTHook(("AWSWMod", 1), func, node)
-    node.next = hook
+    node.chain(hook)
 
     # Put the original next node to the hook node
     # Also keep a copy of the original next node in the hook node, allowing us to unhook it


### PR DESCRIPTION
hook_opcode function doesn't chain ASTHook behind If nodes properly. Hook only works if none of the branches of the If node gets executed. Otherwise the hook gets skipped. This fixes the issue. 