### PR TITLE
Reverting hook chaining behaviour for Label nodes

### DIFF
--- a/modloader/modast.py
+++ b/modloader/modast.py
@@ -479,7 +479,10 @@ def hook_opcode(node, func):
     # The tuple is in the format (filename, filenumber)
     # This is used by the renpy stacktrace
     hook = ASTHook(("AWSWMod", 1), func, node)
-    node.chain(hook)
+    if isinstance(node, ast.Label):
+        node.next = hook
+    else:
+        node.chain(hook)
 
     # Put the original next node to the hook node
     # Also keep a copy of the original next node in the hook node, allowing us to unhook it


### PR DESCRIPTION
The change I made to chaining hooks changed the way hooks chain behind Label nodes. This has a high potential to break existing mods, therefore this changes it to use the old way for Label nodes.