### PR TITLE
Prevent modtools error message if '.DS_Store' is present in mods dir.

### DIFF
--- a/modloader/__init__.py
+++ b/modloader/__init__.py
@@ -134,7 +134,10 @@ def main(reload_mods=False):
     modinfo.reset_mods()
 
     modules = []
+    valid_files = ['.DS_Store']
     for mod in os.listdir(get_mod_path()):
+        if mod in valid_files:
+            continue
         if not os.path.isdir(os.path.join(get_mod_path(), mod)):
             raise EnvironmentError("The contents of the mods folder must all be folders.\n"
                                    "Zip files should be extracted into their own directory as in the core mod.\n"


### PR DESCRIPTION
Modding on MacOS is made a bit of a hassle because any folder operation by Finder in the mods folder leaves the file `.DS_Store` sitting there. As this file is not an intended part of any mod, simply ignoring it is valid.

This change does not harm the user experience (presence of the error message for incorrectly extracted mods) because those mods would have other files, which would still trigger the message. This change improves the user modding experience on Macs, as it removes the necessity to change to the mods directory and delete `.DS_Store` every time a non-trivial change is made to the mods directory.