### PR TITLE
Added dependency system

### DIFF
--- a/modloader/__init__.py
+++ b/modloader/__init__.py
@@ -97,27 +97,25 @@ def update_command():
 
 
 def resolve_dependencies():
-    """Resolve mod dependecies and create mod load order"""
+    """Resolve mod dependencies and create mod load order"""
     from modloader import modinfo
     mod_load_order = []
     load_later = []
     
     # loop through all imported mods
-    for mod_name, mod in modinfo.get_mods().iteritems():
-        mod_deps = mod.mod_info()[-1]
-        
-        # if no dependecies are specified we can just add the mod to mod_load_order
-        if not isinstance(mod_deps, (list, tuple)):
+    for mod_name, mod in modinfo.get_mods().iteritems():        
+        # if no dependencies are specified we can just add the mod to mod_load_order
+        if not hasattr(mod, "dependencies"):
             mod_load_order.append(mod_name)
             continue
         
         # check if all dependecies are imported
-        for mod_dep in mod_deps:
+        for mod_dep in mod.dependencies:
             if not modinfo.has_mod(mod_dep):
-                raise EnvironmentError("Failed resolving dependecies of the mod \"{}\": Cannot find a mod \"{}\".".format(mod_name, mod_dep))
+                raise EnvironmentError("Failed resolving dependencies of the mod \"{}\": Cannot find a mod \"{}\".".format(mod_name, mod_dep))
         
-        # put all mods with dependecies to load_later 
-        load_later.append((mod_name, mod_deps))
+        # put all mods with dependencies to load_later 
+        load_later.append((mod_name, mod.dependencies))
     
     # repeat until there's no mod left in load_later
     while len(load_later) > 0:
@@ -125,11 +123,11 @@ def resolve_dependencies():
         
         # loop through mods which aren't in mod_load_order yet
         for mod_name, mod_deps in load_later:
-            # get dependecies which still aren't in mod_load_order
+            # get dependencies which still aren't in mod_load_order
             later_deps = [mod_dep for mod_dep in mod_deps if mod_dep not in mod_load_order]
             
             # if all dependecies are in mod_load_order, we append the mod to it as well
-            # otherwise we keep it in load_later and shrink the list of dependecies to only the ones which aren't in mod_load_order
+            # otherwise we keep it in load_later and shrink the list of dependencies to only the ones which aren't in mod_load_order
             if len(later_deps) > 0:
                 # the new load_later list is in reversed order to (hopefully) reduce the amount of loops needed
                 new_load_later.insert(0, (mod_name, later_deps))
@@ -138,7 +136,7 @@ def resolve_dependencies():
         
         # if no mod was moved from load_later to mod_load_order, we raise an error to prevent infinite loop
         if len(new_load_later) == len(load_later):
-            raise EnvironmentError("Failed resolving mod dependecies.\nThis may be caused by an occurance of cyclic dependency, which isn't allowed.")
+            raise EnvironmentError("Failed resolving mod dependencies.\nThis may be caused by an occurance of cyclic dependency, which isn't allowed.")
         
         load_later[:] = new_load_later
     

--- a/modloader/__init__.py
+++ b/modloader/__init__.py
@@ -105,11 +105,11 @@ def resolve_dependencies():
     # loop through all imported mods
     for mod_name, mod in modinfo.get_mods().iteritems():        
         # if no dependencies are specified we can just add the mod to mod_load_order
-        if not hasattr(mod, "dependencies"):
+        if not hasattr(mod.__class__, "dependencies"):
             mod_load_order.append(mod_name)
             continue
         
-        # check if all dependecies are imported
+        # check if all dependencies are imported
         for mod_dep in mod.dependencies:
             if not modinfo.has_mod(mod_dep):
                 raise EnvironmentError("Failed resolving dependencies of the mod \"{}\": Cannot find a mod \"{}\".".format(mod_name, mod_dep))

--- a/modloader/modclass.py
+++ b/modloader/modclass.py
@@ -17,7 +17,7 @@ class Mod(object):
         Returns:
             A tuple with the name, version, author, and (optionally) if the mod is NSFW
         """
-        return (self.name, self.version, self.author, self.nsfw if hasattr(self.__class__, "nsfw") else False)
+        return (self.name, self.version, self.author, getattr(self.__class__, "nsfw", False))
 
     def mod_load(self):
         """Executes when the mod is loaded

--- a/modloader/modclass.py
+++ b/modloader/modclass.py
@@ -11,6 +11,8 @@ class Mod(object):
     """
     def mod_info(self):
         """Get the mod info
+        
+        Mod class has to either override this function or contain class attributes `name`, `version`, `author` and optionally `nsfw`.
 
         Returns:
             A tuple with the name, version, author, and (optionally) if the mod is NSFW

--- a/modloader/modclass.py
+++ b/modloader/modclass.py
@@ -9,6 +9,39 @@ class Mod(object):
     Execution order is as follows:
     :meth:`mod_load` -> :meth:`mod_complete`
     """
+    
+    def __init__(self):
+        """Forwards compatibity between mod_info function and class attributes"""
+        
+        cls = self.__class__
+        
+        # check if the class doesn't override mod_info
+        if cls.mod_info == Mod.mod_info:
+            # check mandatory attributes
+            if not hasattr(cls, "name"):
+                raise Exception("Mod must specify the class attribute `name`.")
+            if not hasattr(cls, "version"):
+                raise Exception("Mod must specify the class attribute `version`.")
+            if not hasattr(cls, "author"):
+                raise Exception("Mod must specify the class attribute `author`.")
+        else:
+            # cannot have both mod_info and class attributes
+            if hasattr(cls, "name"):
+                raise Exception("Mod name can only be defined either by class attribute or mod_info function, not both.")
+            if hasattr(cls, "version"):
+                raise Exception("Mod version can only be defined either by class attribute or mod_info function, not both.")
+            if hasattr(cls, "author"):
+                raise Exception("Mod author can only be defined either by class attribute or mod_info function, not both.")
+            if hasattr(cls, "nsfw"):
+                raise Exception("Mod nsfw tag can only be defined either by class attribute or mod_info function, not both.")
+            
+            # set class attributes from mod_info
+            mi = self.mod_info()
+            cls.name = mi[0]
+            cls.version = mi[1]
+            cls.author = mi[2]
+            cls.nsfw = mi[3] if len(mi) >= 4 else False
+    
     def mod_info(self):
         """Get the mod info
         

--- a/modloader/modclass.py
+++ b/modloader/modclass.py
@@ -15,7 +15,7 @@ class Mod(object):
         Returns:
             A tuple with the name, version, author, and (optionally) if the mod is NSFW
         """
-        raise NotImplementedError("Mod info isn't overriden")
+        return (self.name, self.version, self.author, self.nsfw if hasattr(self.__class__, "nsfw") else False)
 
     def mod_load(self):
         """Executes when the mod is loaded

--- a/modloader/modinfo.py
+++ b/modloader/modinfo.py
@@ -12,6 +12,7 @@ except AttributeError:
 
 modlist = {}
 moddirnames = []
+mod_load_order = []
 
 
 def add_mod(mod_name, mod):

--- a/mods/core/__init__.py
+++ b/mods/core/__init__.py
@@ -14,13 +14,9 @@ class AWSWMod(Mod):
 
     This mod is responsible for being a proxy between renpy code and modlib
     """
-
-    @staticmethod
-    def mod_info():
-        """Get the mod info
-        Returns: a three element tuple containing the mod name, version and description
-        """
-        return ("Core", "v0.1", "")
+    name = "Core"
+    version = "v0.1"
+    author = ""
 
     @staticmethod
     def mod_load():


### PR DESCRIPTION
Added dependency system for mods. 
Adding a mod into a list of dependencies of your mod will result in it to always be loaded later than all of its dependencies.
"loaded later" in this case means:
- `mod_load` function will run only after `mod_load` functions of its dependencies already ran
- `mod_complete` function will run only after `mod_complete` functions of its dependencies already ran
- images will have higher priority over images of its dependencies

(the algorithm probably isn't the most efficient one, but I don't really expect massive dependency trees in awsw anyway)