### PR TITLE
Move NSFW button when COMICS button should be shown.

### DIFF
--- a/mods/core/nsfw.rpy
+++ b/mods/core/nsfw.rpy
@@ -16,7 +16,10 @@ init python:
             rpyCode =  'screen mainmenunsfw:\n'\
                         '    imagebutton: \n'\
                         '        xpos 1521 \n'\
-                        '        ypos 223 \n'\
+                        '        if persistent.anygoodending:\n'\
+                        '            ypos 332\n'\
+                        '        else:\n'\
+                        '            ypos 223 \n'\
                         '        auto "ui/nsfwButton_%s.png" \n'\
                         '        action [Show("nsfw_toggle_screen", None, False), Play("audio", "se/sounds/open.wav")] \n'\
                         '        hovered Play("audio", "se/sounds/select.ogg") \n'


### PR DESCRIPTION
Realized this was an issue I could solve with a few lines of code, so I did. Tested both branches and checked the distance to move the button against `image/ui/title/addition2.png`. Looks seamless!