### PR TITLE
Hide modmenu_download from ren'py prediction

### DIFF
--- a/mods/core/core.rpy
+++ b/mods/core/core.rpy
@@ -47,7 +47,7 @@ screen modmenu tag smallscreen:
             vbox xalign 0.5 yalign 0.5:
                 if has_steam():
                     textbutton "Add mod from workshop":
-                        action [Show("check_internet_downloader", use_steam=True),
+                        action [Function(_mod_check_internet_downloader, use_steam=True),
                                 Play("audio", "se/sounds/open.ogg"),
                                 Stop("music", fadeout=1.0),
                                 Play("modmenu_music", "mx/modmenu_music.opus", fadein=1.0),
@@ -57,7 +57,7 @@ screen modmenu tag smallscreen:
 
                 if is_github():
                     textbutton "Add mod from Github":
-                        action [Show("check_internet_downloader", use_steam=False),
+                        action [Function(_mod_check_internet_downloader, use_steam=False),
                                 Play("audio", "se/sounds/open.ogg"),
                                 Stop("music", fadeout=1.0),
                                 Play("modmenu_music", "mx/modmenu_music.opus", fadein=1.0),

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -148,6 +148,22 @@ screen check_internet_downloader(use_steam):
     else:
         use modmenu_nointernet()
 
+
+init -1 python:
+    def _mod_check_internet_downloader(use_steam):
+        if internet_on():
+            # (modid, name, author, description, image) (for github)
+            # (id, name, author, desc, image) (for steam)
+            if use_steam:
+                from modloader.modconfig import steam_downloadable_mods as download_mods
+            else:
+                from modloader.modconfig import github_downloadable_mods as download_mods
+
+            contents = download_mods()
+            renpy.show_screen('modmenu_download', contents=contents, use_steam=use_steam)
+        else:
+            renpy.show_screen('modmenu_nointernet')
+
 screen modmenu_download(contents, use_steam):
     modal True
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -131,24 +131,6 @@ init python:
         return True
 
 
-screen check_internet_downloader(use_steam):
-    modal True
-
-    if internet_on():
-        python:
-            # (modid, name, author, description, image) (for github)
-            # (id, name, author, desc, image) (for steam)
-            if use_steam:
-                from modloader.modconfig import steam_downloadable_mods as download_mods
-            else:
-                from modloader.modconfig import github_downloadable_mods as download_mods
-
-            contents = download_mods()
-        use modmenu_download(contents=contents, use_steam=use_steam)
-    else:
-        use modmenu_nointernet()
-
-
 init -1 python:
     def _mod_check_internet_downloader(use_steam):
         if internet_on():
@@ -186,7 +168,6 @@ screen modmenu_download(contents, use_steam):
             idle "image/ui/close_idle.png"
             hover "image/ui/close_hover.png"
             action [Show("modmenu", transition=dissolve),
-                    Hide("check_internet_downloader", transition=dissolve),
                     Hide("modmenu_mod_content", transition=dissolve),
                     Hide("modmenu_download", transition=dissolve),
                     Stop("modmenu_music", fadeout=1.0),
@@ -468,7 +449,6 @@ screen modmenu_nointernet() tag smallscreen2:
         hbox xalign 0.5 yalign 0.8:
             textbutton "OK.":
                 action [Show("modmenu", transition=dissolve),
-                        Hide("check_internet_downloader", transition=dissolve),
                         Play("audio", "se/sounds/close.ogg")]
                 style "yesnobutton"
 


### PR DESCRIPTION
By embedding accesses of `modmenu_download` inside of a Function() action, Ren'py is unable to access it (and the associated code downloading all mods from Workshop) for prediction. This eliminates the lag-spike bug from closing the mod menu (which would trigger prediction of the `check_internet_downloader` screen.)

As a side-effect, this also eliminates a way to trigger for a crash bug from proposed changes to the steam workshop subsystem, where triggering `GetAllItems()` repeatedly causes it to fill with garbage values. Because `GetAllItems()` is now only run once, when opening the Workshop mods download screen, repeated triggerings (such as repeatedly opening and closing the modmenu and causing Ren'Py prediction to run `check_internet_downloader`) now no longer occur.