### PR TITLE
Startup exceptions show a name of the mod causing them

### DIFF
--- a/modloader/__init__.py
+++ b/modloader/__init__.py
@@ -96,6 +96,13 @@ def update_command():
     update_modtools(args.url)
 
 
+def mod_error(phase, mod_name, e):
+    """Reraise an exception with a name of the mod and its original traceback"""
+    original_msg = "    " + type(e).__name__ + ": " + "\n    ".join(e.message.split("\n"))
+    msg = "\nAn error occured while " + phase + " the mod \"" + mod_name + "\":\n\n"  + original_msg + "\n\nPlease report this issue to the author of this mod."
+    raise Exception, Exception(msg), sys.exc_info()[2]
+
+
 def resolve_dependencies():
     """Resolve mod dependencies and create mod load order"""
     from modloader import modinfo
@@ -214,7 +221,10 @@ def main(reload_mods=False):
         # Try importing the mod.
         # Note: This doesn't give my mod functionality. To give the mod
         # function, make a Mod class and apply the loadable_mod decorator
-        mod_object = importlib.import_module(mod)
+        try:
+            mod_object = importlib.import_module(mod)
+        except Exception as e:
+            mod_error("importing", mod, e)
         if reload_mods:
             rreload(mod_object, modules)
     
@@ -232,12 +242,18 @@ def main(reload_mods=False):
     # Then loop through the mods in their load order and call their respective mod_load functions
     for mod_name in modinfo.mod_load_order:
         print "Loading mod {}".format(mod_name)
-        modinfo.get_mod(mod_name).mod_load()
+        try:
+            modinfo.get_mod(mod_name).mod_load()
+        except Exception as e:
+            mod_error("loading", mod_name, e)
     
     # After all mods are loaded, call their respective mod_complete functions
     for mod_name in modinfo.mod_load_order:
         print "Completing mod {}".format(mod_name)
-        modinfo.get_mod(mod_name).mod_complete()
+        try:
+            modinfo.get_mod(mod_name).mod_complete()
+        except Exception as e:
+            mod_error("completing", mod_name, e)
 
     # Force renpy to reindex all game files
     renpy.loader.old_config_archives = None


### PR DESCRIPTION
During importing, loading and completing of mods, all exceptions get caught and reraised with a name of the mod which caused them included in the error message. Original traceback is preserved.

Visibly showing a name of the mod causing the startup error should be very helpful for normal players who don't want to dig through the traceback and just want to know which mod author to scream at.