### PR TITLE
Add __eq__ method to MTSTogglePersistentBool to match Ren'Py Action

### DIFF
--- a/mods/core/mts_useful_functions.rpy
+++ b/mods/core/mts_useful_functions.rpy
@@ -88,6 +88,11 @@ init -100 python:
         def __init__(self, name):
             self.name = name
 
+        def __eq__(self, other):
+            if not isinstance(other, MTSTogglePersistentBool):
+                return False
+            return self.name == other.name
+
         def __call__(self):
             #if it's true
             if getattr(persistent, self.name):


### PR DESCRIPTION
Base modtools has a Ren'Py-style `Action`: `MTSTogglePersistentBool`, which does not have a definition for `__eq__`. Base Python behaviour for classes without `__eq__` is to do _reference_ equality rather than _field_ equality, so `MTSTogglePersistentBool('my_variable')==MTSTogglePersistentBool('my_variable')` is `False`. Ren'Py actions have a notion of equality defined such that actions should be equal if they are indistinguishable, which they are in this case.

This causes Ren'Py to have to re-render every checkbox on every modded-in menu every frame. Fixing this shaved a flat millisecond off MusicViewer menu's update times, which only uses 5 checkboxes. It's probably even more significant in some of my other mods' screens.

This PR provides a definition for `__eq__` for `MTSTogglePersistentBool`.