### PR TITLE
Implement mod zip unpacking 

### DIFF
--- a/modloader/modzip.py
+++ b/modloader/modzip.py
@@ -1,0 +1,74 @@
+import os.path
+import shutil
+import zipfile
+
+__all__ = ('unpack',)
+
+def _zip_security_check(zip_path, member_name):
+    def fail(msg):
+        # Note: We _intentionally_ don't print the member_name here,
+        # as it could be used to abuse the error message to give the
+        # user malicious instructions.
+        # It's up to the user to complain about the error message to
+        # the mod author, who can fix the zip if they're not malicious.
+        raise EnvironmentError("Zip file {} contains {} in a member path. For security reasons this is not allowed.".format(zip_path, msg))
+    if '..' in member_name:
+        fail('".." (directory climbing)')
+    if '\\' in member_name:
+        fail('"\\" (backslash)')
+    if member_name.startswith('/'):
+        fail('absolute paths')
+    if member_name.startswith('./'):
+        fail('relative paths')
+    return True
+
+def _unpack_zip_path_to_path(zip_file, subpath, target_path, debug=False):
+    if subpath and subpath[-1] != '/':
+        subpath += '/'
+    for name in zip_file.namelist():
+        if name.startswith(subpath) and name != subpath:
+            zipinfo_obj = zip_file.getinfo(name)
+            old_filename = zipinfo_obj.filename
+            zipinfo_obj.filename = name[len(subpath):]
+            if debug:
+                print(zipinfo_obj.filename, '=>', os.path.join(target_path, zipinfo_obj.filename))
+            zip_file.extract(name, target_path)
+            zipinfo_obj.filename = old_filename
+
+def unpack(zip_path, verbose=False, debug=False):
+    # Check for an unpacked folder at the same location as the zip but without the .zip extension
+    folder_path = zip_path[:-4]
+    if os.path.isdir(folder_path):
+        # Check if the zip file is newer than the folder
+        if os.path.getmtime(zip_path) < os.path.getmtime(folder_path):
+            if verbose:
+                print('Folder "{}" is up to date from zip "{}". Skipping...'.format(folder_path, zip_path))
+            return None
+        else:
+            if verbose:
+                print('Folder "{}" is outdated from zip "{}". Replacing...'.format(folder_path, zip_path))
+            shutil.rmtree(folder_path)
+    with zipfile.ZipFile(zip_path, 'r') as z:
+        # Now we need to make sure we're extracting the right nesting depth
+        # If there is an __init__.py file in the root of the zip, extract that level.
+        # Otherwise, check if there's a folder in the root of the zip and recurse to check for __init__.py
+        # Repeat until we either have to choose between multiple folders or we find an __init__.py
+        # Extract the complete contents of the folder with the __init__.py
+        # If there is no __init__.py, raise an error
+        for name in z.namelist():
+            _zip_security_check(zip_path, name)
+        init_files = [f for f in z.namelist() if f.endswith('__init__.py')]
+        if len(init_files) == 0:
+            raise EnvironmentError("Zip file {} does not appear to be a packaged mod. It is missing an __init__.py file.".format(zip_path))
+        # Sort the init profiles by path depth
+        init_files.sort(key=lambda x: x.count('/'))
+        # Check if the first two items have the same depth, if so error out
+        if len(init_files) > 1 and init_files[0].count('/') == init_files[1].count('/'):
+            raise EnvironmentError("Zip file {} contains multiple __init__.py files at the shallowest depth. Cannot determine which to extract.".format(zip_path))
+        # Extract the folder containing the __init__.py file
+        init_path = init_files[0]
+        mod_path = init_path.rsplit('/', 1)[0] if '/' in init_path else ''
+        if verbose:
+            print('Extracting "{}" into "{}"'.format(os.path.join(zip_path,mod_path), folder_path))
+        _unpack_zip_path_to_path(z, mod_path, folder_path, debug=debug)
+    return folder_path


### PR DESCRIPTION
As it says on the tin, implements unpacking of zip files that contain acceptably-formatted AwSW mods.

### Purpose

To make non-Steam-Workshop mod installation easier.

### Code process

After the mod folder list is compiled with `reset_mods()`, but before any mods are imported, this PR separates out and removes files whose lowercase path end in ".zip".

The implementation assumes the mod is implemented using an `__init__.py` at the root of the mod directory, as is the currently accepted mod format. It solves for zip files being nasty and nesting folders by finding the shallowest folder containing an `__init__.py` and extracting that + all siblings and siblings' descendants. If multiple folders have an `__init__.py` at the same depth, it errors out. If no `__init__.py` exists in the zip, it errors out.

The folder name for the extracted mod is the name of the zip without the ".zip" extension. If a folder already exists with that name, the `m_time` of the zip and folder are compared. If the zip is newer, the folder is recursively deleted and the zip file's contents are extracted into a fresh folder.

This process is performed for all zip files found in the mod directory. If any zip has been unpacked (after the `m_time` checks) then the game restarts entirely, exactly as if the user had clicked `Remove mod and reload` on an error screen.

### Drawbacks

* Fully reloads the game if any zips get unpacked. Not bad per-se but means it takes a few more seconds to boot on mod update on underpowered platforms. Only adds minimal overhead (stat n zip files, stat n folders up to twice) on subsequent boots.