### PR TITLE
Add duplicate mod import check and user-friendly error screen

### DIFF
--- a/modloader/modinfo.py
+++ b/modloader/modinfo.py
@@ -3,6 +3,7 @@
 
 import os.path
 from os import listdir
+from collections import defaultdict
 try:
     import renpy.config
 except AttributeError:
@@ -14,15 +15,37 @@ modlist = {}
 moddirnames = []
 mod_load_order = []
 
+# Error catching: if the same name is repeated,
+# save the old copies so we can report a detailed error.
+overloaded_mod_names = defaultdict(list)
 
 def add_mod(mod_name, mod):
     """Add a mod in the registry"""
     print "Adding mod {}".format(mod_name)
+    if mod_name in modlist:
+        print("IMPORT ISSUE: Given a mod name of {0!r} by both {1!r} and {2!r}.".format(mod_name, modlist[mod_name].__module__, mod.__module__))
+        overloaded_mod_names[mod_name].append(modlist[mod_name])
     modlist[mod_name] = mod
 
 
 def get_mods():
     """Get the mods in the registry"""
+    if overloaded_mod_names:
+        # Error: can't have multiple mods with the same name.
+        # Report the error now, as we've likely finished
+        # importing all mods, so have captured the full issue.
+        from modloader import report_mod_errors
+        complete_overloads = {
+            mod_name: mod_classes + [modlist[mod_name]] for mod_name, mod_classes in overloaded_mod_names.items()
+        }
+        formatted_overloads = {
+            mod_name: " and ".join("{0!r}".format(mod_class.__module__) for mod_class in mod_classes) for mod_name, mod_classes in complete_overloads.items()
+        }
+        report_mod_errors(
+            "While importing mods, ones with the same name were installed in multiple folders.\n\n"
+            + "\n".join("  Mods named {0!r} were installed in {1}".format(mod_name, formatted_overload_list) for mod_name, formatted_overload_list in formatted_overloads.items())
+            + "\n\nPlease remove the duplicated mods or change the names in their metadata."
+        )
     return modlist
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ef2ef18d-0cbf-4077-be0b-6711876474de)

Detects when mods are imported from multiple places, but their metadata reports the same name. Prevents the user/mod developer from launching the game fully until this name duplication has been resolved.

Without this, current behavior is to import the `__init__.py` and `*.rpy` files of both mods, but silently only call `mod_load` and `mod_complete` on whichever mod was imported second. Without duplicate labels in `*.rpy` files, this could be entirely silent and result in numerous confusing behaviors.

Credit to JoeyJumper94 for exposing this issue with a heisenbug that had different behavior on Linux vs Wine (due to different folder sort order.)