### PR TITLE
Preload modmenu images

### DIFF
--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -16,7 +16,7 @@ from renpy.ui import Action
 from renpy.exports import show_screen
 
 from modloader.modinfo import get_mods
-from modloader.preload import PreloadBase
+from modloader.preload import Preload
 from modloader import get_mod_path, workshop_enabled
 if workshop_enabled:
     from steam_workshop.steam_config import has_valid_signature, MODTOOLS_ID
@@ -100,44 +100,31 @@ def github_downloadable_mods():
 
 
 
-class SteamModlist(PreloadBase):
-    """Manages the steam modlist, as is gotten by the steam_downloadable_mods method.
-    It supports loading the modlist in a separate thread, and caching such results.
-    This is needed as loading the modlist takes quite a while,
-      And is an operation we would much rather do at startup, without delaying anything else.
-    """
+def load_steam_modlist():
+    """Loads and verifies the steam modlist data."""
+    # A different format,
+    # (id, mod_name, author, desc, image_url)
     
-    def loading_function(self):
-        """Loads and verifies the steam modlist data.
-        It must take no arguments, and return a single value: the loaded data.
-        It may raise an exception, in which case it'll be stored in self._exception.
-        """
-        # A different format,
-        # (id, mod_name, author, desc, image_url)
-        
-        # This uses GetAllItems(), Which is affected by the QueryApi crash.
-        #   therefore, steamhandler_extensions are preferred
-        mods = []
-        for mod in sorted(steamhandler_extensions.get_instance().GetAllItems(), key=lambda mod: mod[1]):
-            if mod[0] == MODTOOLS_ID:
-                continue  # The modtools themselves need not be here (as they're already present and can't be removed using themselves), nor should the signing system complain about them...
-            file_id = mod[0]
-            create_time, modify_time, signature = mod[5:8]
-            is_valid, verified = has_valid_signature(file_id, create_time, modify_time, signature)
-            if is_valid:
-                mods.append(list(mod[:5]))
-                mods[-1][3] += "\n\nVerified by {}".format(verified.username.replace("<postmaster@example.com>", ""))
-            else:
-                print "NOT VALID SIG", mod[1]  # Note: printing only the mod name, instead of the whole thing SIGNIFICANTLY speeds up this call
-        return mods
-    
+    # This uses GetAllItems(), Which is affected by the QueryApi crash.
+    #   therefore, steamhandler_extensions are preferred
+    mods = []
+    for mod in sorted(steamhandler_extensions.get_instance().GetAllItems(), key=lambda mod: mod[1]):
+        if mod[0] == MODTOOLS_ID:
+            continue  # The modtools themselves need not be here (as they're already present and can't be removed using themselves), nor should the signing system complain about them...
+        file_id = mod[0]
+        create_time, modify_time, signature = mod[5:8]
+        is_valid, verified = has_valid_signature(file_id, create_time, modify_time, signature)
+        if is_valid:
+            mods.append(list(mod[:5]))
+            mods[-1][3] += "\n\nVerified by {}".format(verified.username.replace("<postmaster@example.com>", ""))
+        else:
+            print "NOT VALID SIG", mod[1]  # Note: printing only the mod name, instead of the whole thing SIGNIFICANTLY speeds up this call
+    return mods
 
-
-steam_mod_list = SteamModlist(1) # As loading the steam modlist is a single-threaded thing, there's no reason to reserve many threads to it...
-
+steam_modlist_preloader = Preload(load_steam_modlist, 1) # As loading the steam modlist is a single-threaded thing, there's no reason to reserve many threads to it...
 
 def steam_downloadable_mods():
-    return steam_mod_list.get()
+    return steam_modlist_preloader.get()
 
 
 def download_github_mod(download_link, name, show_download=True, reload_script=True):

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -8,8 +8,6 @@ from urllib2 import urlopen
 import json
 from cStringIO import StringIO
 import zipfile
-from collections import namedtuple
-import threading
 
 import renpy
 from renpy.audio.music import stop as _stop_music
@@ -18,6 +16,7 @@ from renpy.ui import Action
 from renpy.exports import show_screen
 
 from modloader.modinfo import get_mods
+from modloader.preload import PreloadBase
 from modloader import get_mod_path, workshop_enabled
 if workshop_enabled:
     from steam_workshop.steam_config import has_valid_signature, MODTOOLS_ID
@@ -100,11 +99,8 @@ def github_downloadable_mods():
     return sorted(data, key=lambda mod: mod[1].lower())
 
 
-class TimeoutError(Exception):
-    """Represents a timeout for waiting for a load. mostly allows the timeout parameter in the get() method, to differentiate between a timeout and a failure."""
-    pass
 
-class SteamModlist:
+class SteamModlist(PreloadBase):
     """Manages the steam modlist, as is gotten by the steam_downloadable_mods method.
     It supports loading the modlist in a separate thread via the load method,
     And caching such results.
@@ -114,19 +110,11 @@ class SteamModlist:
     Once the load finishes, get() will either return a value (if no exception was raised during loading), or raise the exception raised during loading.
     """
     
-    def __init__(self):
-        self._loading_thread = None
-        self._loading_thread_lock = threading.Lock()
-        self._loaded_data = None
-        self._exception = None
-        self._is_loaded = threading.Event()
-    
-    def _loading_function(self):
+    def loading_function(self):
         """Loads and verifies the steam modlist data.
         It must take no arguments, and return a single value: the loaded data.
         It may raise an exception, in which case it'll be stored in self._exception.
         """
-        
         # A different format,
         # (id, mod_name, author, desc, image_url)
         
@@ -146,72 +134,6 @@ class SteamModlist:
                 print "NOT VALID SIG", mod[1]  # Note: printing only the mod name, instead of the whole thing SIGNIFICANTLY speeds up this call
         return mods
     
-    def _load_and_set(self):
-        """Calls the _loading_function and sets the internal values based on its results."""
-        try:
-            mods = self._loading_function()
-            self._loaded_data = mods
-            print "Finished steam modlist load without errors"
-        except Exception as e:
-            print "Finished steam modlist load with errors"
-            self._exception = e
-            self._exception.traceback = sys.exc_info()[2]
-        
-        self._is_loaded.set()
-        print "Done loading steam modlist"
-        return
-    
-    def load(self):
-        """Starts loading the steam modlist data if it is not already being loaded.
-        This method starts a thread which loads the modlist data.
-        It guarantees that for any number of repeated calls to it from any number of threads, only one loading thread will be started.
-        Once the data is loaded, it is available through the get method.
-        """
-        with self._loading_thread_lock:
-            if self._loading_thread is None:
-                print "Steam modlist thread not present, Starting..."
-                self._loading_thread = threading.Thread(target=self._load_and_set, name=u"Thread-load-SteamModlist")
-                self._loading_thread.start()
-            else:
-                print "Steam modlist thread already present"
-        return self._loading_thread
-    
-    def get(self, timeout=None):
-        """Get the steam modlist data.
-        If the data has already loaded, this method returns with it immediately,
-        Otherwise, load() is called, and this method blocks using self.wait(timeout).
-        :returns steam modlist data, If timeout has not been reached and the loading thread has not raised an error.
-        :raises Exception, If timeout has not been reached and the loading thread has raised an error. this raises that very exception.
-        :raises TimeoutError, If timeout has been reached.
-        """
-        if self.is_loaded():
-            # Note: while the value of is_done can change between checking it here and referring to _loaded_data,
-            #  It can only change from False to True.
-            #  In that case the load() method has been called before and is currently finishing,
-            #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
-            
-            print "Steam modlist data already available"
-        else:
-            print "Steam modlist data not available, calling load"
-            self.load()
-            self.wait(timeout)
-            print "Loading done, fetching data"
-        
-        if self._exception is not None:
-            raise self._exception
-        
-        return self._loaded_data
-    
-    def is_loaded(self):
-        return self._is_loaded.is_set()
-    
-    def wait(self, timeout=None):
-        """Waits for timeout seconds until loading is finished. if timeout is None (default), waits indefinitely until loading is finished.
-        :returns None if loading is finished before timeout elapsed.
-        :raises TimeoutError if timeout has expired before loading is finished."""
-        if not self._is_loaded.wait(timeout):
-            raise TimeoutError(type(self).__name__)
-        return
 
 
 steam_mod_list = SteamModlist()

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -102,12 +102,9 @@ def github_downloadable_mods():
 
 class SteamModlist(PreloadBase):
     """Manages the steam modlist, as is gotten by the steam_downloadable_mods method.
-    It supports loading the modlist in a separate thread via the load method,
-    And caching such results.
+    It supports loading the modlist in a separate thread, and caching such results.
     This is needed as loading the modlist takes quite a while,
       And is an operation we would much rather do at startup, without delaying anything else.
-    Any exceptions raised in the loading process will be available through the get() method.
-    Once the load finishes, get() will either return a value (if no exception was raised during loading), or raise the exception raised during loading.
     """
     
     def loading_function(self):
@@ -136,7 +133,7 @@ class SteamModlist(PreloadBase):
     
 
 
-steam_mod_list = SteamModlist()
+steam_mod_list = SteamModlist(1) # As loading the steam modlist is a single-threaded thing, there's no reason to reserve many threads to it...
 
 
 def steam_downloadable_mods():

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -121,7 +121,7 @@ def load_steam_modlist():
             print "NOT VALID SIG", mod[1]  # Note: printing only the mod name, instead of the whole thing SIGNIFICANTLY speeds up this call
     return mods
 
-steam_modlist_preloader = Preload(load_steam_modlist, 1) # As loading the steam modlist is a single-threaded thing, there's no reason to reserve many threads to it...
+steam_modlist_preloader = Preload(load_steam_modlist) # As loading the steam modlist is a single-threaded thing, there's no reason to reserve many threads to it...
 
 def steam_downloadable_mods():
     return steam_modlist_preloader.get()

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -307,6 +307,7 @@ class Preload:
         :returns preloaded result of loading_function(*args), If timeout has not been reached and the loading thread has not raised an error.
         :raises Exception, If timeout has not been reached and the loading thread has raised an error. this raises that very exception.
         :raises TimeoutError, If timeout has been reached.
+        :raises ClearingError, If a clear() call was preformed during this get() call
         """
         if "timeout" in kwargs:
             timeout = kwargs["timeout"]
@@ -314,18 +315,23 @@ class Preload:
             timeout = None
         
         with self._clear_session_lock:
-            if self.is_loaded(*args):
-                # Note: while the value of is_loaded can change between checking it here and referring to _loaded_data,
-                #  It can only change from False to True.
-                #  In that case the load() method has been called before and is currently finishing,
-                #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
-                
-                print "({}) Preload data already available: {}".format(self._name, args)
-            else:
-                print "({}) Preload data not available, calling load: {}".format(self._name, args)
-                self.load(*args)
-                self.wait(*args, timeout=timeout)
+            start_session_num = self._clear_session_num
+        
+        if self.is_loaded(*args):
+            # Note: while the value of is_loaded can change between checking it here and referring to _loaded_data,
+            #  It can only change from False to True.
+            #  In that case the load() method has been called before and is currently finishing,
+            #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
             
+            print "({}) Preload data already available: {}".format(self._name, args)
+        else:
+            print "({}) Preload data not available, calling load: {}".format(self._name, args)
+            self.load(*args)
+            self.wait(*args, timeout=timeout)
+        
+        with self._clear_session_lock:
+            if not start_session_num == self._clear_session_num:
+                raise ClearingError("get({}, {})".format(args, kwargs))
             with self._load_data_lock:
                 if self._exception[args] is not None: # by this point, args must be present in both data dicts
                     raise self._exception[args]
@@ -395,7 +401,9 @@ class Preload:
         """Waits for timeout seconds until loading is finished. if timeout is None (default), waits indefinitely until loading is finished.
         :parameter timeout - name only (default None) - the number of seconds to wait. by default - indefinitely.
         :returns None if loading is finished before timeout elapsed.
-        :raises TimeoutError if timeout has expired before loading is finished."""
+        :raises KeyError if waiting upon a non-loading key.
+        :raises TimeoutError if timeout has expired before loading is finished.
+        :raises ClearingError if cleared during this wait (invalidation)."""
         if "timeout" in kwargs:
             timeout = kwargs["timeout"]
         else:
@@ -405,10 +413,24 @@ class Preload:
             with self._is_loaded_lock:
                 try:
                     correct_is_done = self._is_loaded[args] # lock should only protect dict access and should never contain blocking actions.
-                except AttributeError:
-                    raise ClearingError("wait{}".format(args))
+                except KeyError:
+                    raise KeyError("[{}] Key {} cannot be waited upon, as it is not being loaded".format(self._name, args))
+            clear_session = self._clear_session_num
+        
+        timeout_numeric = timeout if timeout is not None else 1.0 # Much simpler logic
+        # As clearing should interrupt any wait actions, we unfortunately can't just call wait(timeout) and be done with it.
+        while True:
+            is_done = correct_is_done.wait(min(1.0, timeout_numeric))
             
-        if not correct_is_done.wait(timeout):
-            raise TimeoutError(type(self).__name__)
-        return
+            if not self._is_clear_session_valid(clear_session):
+                raise ClearingError("wait({})".format(args))
+            
+            if is_done:
+                return
+            
+            if timeout is not None:
+                timeout -= 1.0
+                timeout_numeric = timeout
+                if timeout < 0.0:
+                    raise TimeoutError(type(self).__name__)
     

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -11,6 +11,10 @@ class TimeoutError(Exception):
     """A timeout for waiting for a load. mostly allows the timeout parameter in the get() method, to differentiate between a timeout and a failure."""
     pass
 
+class ClearingError(Exception):
+    """An action that was made invalid via a clear() call"""
+    pass
+
 class Empty(TimeoutError):
     """A pop operation on an empty queue"""
     pass
@@ -48,6 +52,10 @@ class Queue:
                         timeout -= time.time() - s_time
                         if timeout < 0:
                             raise Empty()
+    
+    def clear(self):
+        self._queue.clear()
+        return
     
     def get_nowait(self):
         self.get(False)
@@ -226,22 +234,29 @@ class Preload:
         self._is_loaded = {} # Presence of a key here is used to detect if that said key is being loaded
         self._is_loaded_lock = threading.Lock()
         
+        self._clear_session_num = 0 # clear() uses session numbers to ensure that once clear is called, all ongoing actions are invalidated
+        self._clear_session_lock = threading.RLock()
+        
         return
     
     def _manage_job_queue(self):
         while True:
             next_job = self._job_queue.get()
-            job_type = next_job[0]
+            print "[{}]{} next job: {} ({})".format(self._clear_session_num, self._name, next_job[1], next_job[2:])
+            job_clear_session = next_job[0]
+            if not self._is_clear_session_valid(job_clear_session):
+                continue
+            job_type = next_job[1]
             if job_type is "load":
-                self._load_and_set(*next_job[1])
+                self._load_and_set(job_clear_session, *next_job[2])
             elif job_type is "callback":
-                new_callback, finished_loads = next_job[1], next_job[2]
-                self._call_callbacks(finished_loads, (new_callback,))
+                new_callback, finished_loads = next_job[2], next_job[3]
+                self._call_callbacks(finished_loads, (new_callback,), clear_session=job_clear_session)
             else:
                 raise ValueError("Unrecogised job of type: \"{}\"".format(job_type))
     
     
-    def _load_and_set(self, *args):
+    def _load_and_set(self, clear_session, *args):
         """Calls the _loading_function and stores it results for get()."""
         try:
             data = self._loading_function(*args)
@@ -253,15 +268,18 @@ class Preload:
             exception = e
             exception.traceback = sys.exc_info()[2]  # Adding traceback information to e
         
-        with self._load_data_lock:
-            self._loaded_data[args] = data
-            self._exception[args] = exception
-            curr_callbacks = tuple(self._callbacks)
-        
-        with self._is_loaded_lock:
-            self._is_loaded[args].set()
-        # print "Done preloading"
-        self._call_callbacks((args,), curr_callbacks)
+        with self._clear_session_lock:
+            if not self._is_clear_session_valid(clear_session):
+                return # Invalidated
+            with self._load_data_lock:
+                self._loaded_data[args] = data
+                self._exception[args] = exception
+                curr_callbacks = tuple(self._callbacks)
+            
+            with self._is_loaded_lock:
+                self._is_loaded[args].set()
+            # print "Done preloading"
+            self._call_callbacks((args,), curr_callbacks, clear_session=self._clear_session_num)
         return
     
     def load(self, *args):
@@ -269,15 +287,16 @@ class Preload:
         It guarantees that for any number of repeated calls to it from any number of threads, loading_function() will only be called once for each distinct args.
         Once the data is loaded, it is available through the get() method.
         """
-        with self._is_loaded_lock:
-            if args in self._is_loaded:
-                print "({}) Preload already present: {}".format(self._name, args)
-                return
+        with self._clear_session_lock:
+            with self._is_loaded_lock:
+                if args in self._is_loaded:
+                    print "({}) Preload already present: {}".format(self._name, args)
+                    return
+                
+                self._is_loaded[args] = threading.Event()
             
-            self._is_loaded[args] = threading.Event()
-        
-        print "({}) Preload not present, Starting... {}".format(self._name, args)
-        self._job_queue.put(("load", args))
+            print "({}) Preload not present, Starting... {}".format(self._name, args)
+            self._job_queue.put((self._clear_session_num, "load", args))
         return
     
     def get(self, *args, **kwargs):
@@ -294,23 +313,40 @@ class Preload:
         else:
             timeout = None
         
-        if self.is_loaded(*args):
-            # Note: while the value of is_loaded can change between checking it here and referring to _loaded_data,
-            #  It can only change from False to True.
-            #  In that case the load() method has been called before and is currently finishing,
-            #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
+        with self._clear_session_lock:
+            if self.is_loaded(*args):
+                # Note: while the value of is_loaded can change between checking it here and referring to _loaded_data,
+                #  It can only change from False to True.
+                #  In that case the load() method has been called before and is currently finishing,
+                #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
+                
+                print "({}) Preload data already available: {}".format(self._name, args)
+            else:
+                print "({}) Preload data not available, calling load: {}".format(self._name, args)
+                self.load(*args)
+                self.wait(*args, timeout=timeout)
             
-            print "({}) Preload data already available: {}".format(self._name, args)
-        else:
-            print "({}) Preload data not available, calling load: {}".format(self._name, args)
-            self.load(*args)
-            self.wait(*args, timeout=timeout)
-        
-        with self._load_data_lock:
-            if self._exception[args] is not None: # by this point, args must be present in both data dicts
-                raise self._exception[args]
-            
-            return self._loaded_data[args]
+            with self._load_data_lock:
+                if self._exception[args] is not None: # by this point, args must be present in both data dicts
+                    raise self._exception[args]
+                
+                return self._loaded_data[args]
+    
+    def clear(self):
+        """Clears the loaded data, along with any ongoing loading and callback actions.
+        Note that it can't stop them outright, but it invalidates their results."""
+        with self._clear_session_lock:
+            print "Clearing {}".format(self._name)
+            self._clear_session_num += 1
+            self._loaded_data.clear()
+            self._exception.clear()
+            self._is_loaded.clear()
+            self._job_queue.clear()
+            return
+    
+    def _is_clear_session_valid(self, clear_session):
+        with self._clear_session_lock:
+            return clear_session == self._clear_session_num
     
     
     def register_callback(self, callback):
@@ -320,24 +356,30 @@ class Preload:
         It is guaranteed that each callback will eventually run exactly once on each load.
         """
         
-        with self._load_data_lock:
-            self._callbacks.append(callback)
-            finised_loads = tuple(self._loaded_data.keys())
+        with self._clear_session_lock:
+            with self._load_data_lock:
+                self._callbacks.append(callback)
+                finised_loads = tuple(self._loaded_data.keys())
         
-        self._job_queue.put(("callback", callback, finised_loads))
+            self._job_queue.put((self._clear_session_num, "callback", callback, finised_loads))
         return
     
-    def _call_callbacks(self, loads, callbacks):
+    def _call_callbacks(self, loads, callbacks, clear_session):
         """calls each callback in callbacks on each result of loads"""
         for load_key in loads:
             data = None
             exception = None
             try:
-                data = self.get(*load_key)
+                with self._clear_session_lock:
+                    if not self._is_clear_session_valid(clear_session):
+                        return # Once a clear session passes, this whole thing is invalidated
+                    data = self.get(*load_key)
             except Exception as e:
                 exception = e
             for callback in callbacks:
                 try:
+                    if not self._is_clear_session_valid(clear_session):
+                        return # Once a clear session passes, this whole thing is invalidated
                     callback(data, exception)
                 except Exception: # callback exceptions are ignored and do not affect other callbacks.
                     pass
@@ -345,8 +387,9 @@ class Preload:
     
     
     def is_loaded(self, *args):
-        with self._is_loaded_lock:
-            return args in self._is_loaded and self._is_loaded[args].is_set()
+        with self._clear_session_lock:
+            with self._is_loaded_lock:
+                return args in self._is_loaded and self._is_loaded[args].is_set()
     
     def wait(self, *args, **kwargs):
         """Waits for timeout seconds until loading is finished. if timeout is None (default), waits indefinitely until loading is finished.
@@ -358,8 +401,12 @@ class Preload:
         else:
             timeout = None
         
-        with self._is_loaded_lock:
-            correct_is_done = self._is_loaded[args] # lock should only protect dict access and should never contain blocking actions.
+        with self._clear_session_lock:
+            with self._is_loaded_lock:
+                try:
+                    correct_is_done = self._is_loaded[args] # lock should only protect dict access and should never contain blocking actions.
+                except AttributeError:
+                    raise ClearingError("wait{}".format(args))
             
         if not correct_is_done.wait(timeout):
             raise TimeoutError(type(self).__name__)

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -1,94 +1,297 @@
+import collections
 import threading
 import sys
+import time
+import os
+import re
+import subprocess
 from abc import ABCMeta, abstractmethod
 
 
 class TimeoutError(Exception):
-    """Represents a timeout for waiting for a load. mostly allows the timeout parameter in the get() method, to differentiate between a timeout and a failure."""
+    """A timeout for waiting for a load. mostly allows the timeout parameter in the get() method, to differentiate between a timeout and a failure."""
     pass
 
+class Empty(TimeoutError):
+    """A pop operation on an empty queue"""
+    pass
+
+class Queue:
+    """As Queue.Queue isn't available, we make our own. maxsize isn't supported."""
+    
+    def __init__(self):
+        self._queue = collections.deque()
+        self._pop_condition = threading.Condition()
+        return
+    
+    
+    def put(self, item):
+        with self._pop_condition:
+            self._queue.append(item)
+            self._pop_condition.notify()
+        return
+    
+    def get(self, block=True, timeout=None):
+        if not block or timeout == 0: # For these non-blocking cases, We avoid the retrying located below.
+            try:
+                return self._queue.popleft()
+            except IndexError:
+                raise Empty()
+            
+        with self._pop_condition:
+            while True:
+                try:
+                    return self._queue.popleft()
+                except IndexError:
+                    s_time = time.time()
+                    self._pop_condition.wait(timeout)
+                    if timeout is not None:
+                        timeout -= time.time() - s_time
+                        if timeout < 0:
+                            raise Empty()
+    
+    def get_nowait(self):
+        self.get(False)
+
+
+# As we effectively use a threadpool for the preload class, we wish to access the cpu count of the machine to allow a logical default number of threads.
+#   multiprocessing (the standard way to check) is not available, so we use this one.
+# Source - https://stackoverflow.com/a/1006301
+# Posted by phihag, modified by community. See post 'Timeline' for change history
+# Retrieved 2026-04-07, License - CC BY-SA 4.0
+def available_cpu_count():
+    """ Number of available virtual or physical CPUs on this system, i.e.
+    user/real as output by time(1) when called with an optimally scaling
+    userspace-only program"""
+
+    # cpuset
+    # cpuset may restrict the number of *available* processors
+    try:
+        m = re.search(r'(?m)^Cpus_allowed:\s*(.*)$',
+                      open('/proc/self/status').read())
+        if m:
+            res = bin(int(m.group(1).replace(',', ''), 16)).count('1')
+            if res > 0:
+                return res
+    except IOError:
+        pass
+
+    # Python 2.6+
+    try:
+        import multiprocessing
+        return multiprocessing.cpu_count()
+    except (ImportError, NotImplementedError):
+        pass
+
+    # https://github.com/giampaolo/psutil
+    try:
+        import psutil
+        return psutil.cpu_count()   # psutil.NUM_CPUS on old versions
+    except (ImportError, AttributeError):
+        pass
+
+    # POSIX
+    try:
+        res = int(os.sysconf('SC_NPROCESSORS_ONLN'))
+
+        if res > 0:
+            return res
+    except (AttributeError, ValueError):
+        pass
+
+    # Windows
+    try:
+        res = int(os.environ['NUMBER_OF_PROCESSORS'])
+
+        if res > 0:
+            return res
+    except (KeyError, ValueError):
+        pass
+
+    # jython
+    try:
+        from java.lang import Runtime
+        runtime = Runtime.getRuntime()
+        res = runtime.availableProcessors()
+        if res > 0:
+            return res
+    except ImportError:
+        pass
+
+    # BSD
+    try:
+        sysctl = subprocess.Popen(['sysctl', '-n', 'hw.ncpu'],
+                                  stdout=subprocess.PIPE)
+        scStdout = sysctl.communicate()[0]
+        res = int(scStdout)
+
+        if res > 0:
+            return res
+    except (OSError, ValueError):
+        pass
+
+    # Linux
+    try:
+        res = open('/proc/cpuinfo').read().count('processor\t:')
+
+        if res > 0:
+            return res
+    except IOError:
+        pass
+
+    # Solaris
+    try:
+        pseudoDevices = os.listdir('/devices/pseudo/')
+        res = 0
+        for pd in pseudoDevices:
+            if re.match(r'^cpuid@[0-9]+$', pd):
+                res += 1
+
+        if res > 0:
+            return res
+    except OSError:
+        pass
+
+    # Other UNIXes (heuristic)
+    try:
+        try:
+            dmesg = open('/var/run/dmesg.boot').read()
+        except IOError:
+            dmesgProcess = subprocess.Popen(['dmesg'], stdout=subprocess.PIPE)
+            dmesg = dmesgProcess.communicate()[0]
+
+        res = 0
+        while '\ncpu' + str(res) + ':' in dmesg:
+            res += 1
+
+        if res > 0:
+            return res
+    except OSError:
+        pass
+
+    raise Exception('Can not determine number of CPUs on this system')
+
+
+
 class PreloadBase:
-    """Manages the steam modlist, as is gotten by the steam_downloadable_mods method.
-    It supports loading the modlist in a separate thread via the load method,
-    And caching such results.
-    This is needed as loading the modlist takes quite a while,
-      And is an operation we would much rather do at startup, without delaying anything else.
-    Any exceptions raised in the loading process will be available through the get_exception() method.
-    Once the load finishes, Only one of the get() and get_exception() methods will return a value, while the other will return None.
-      If the load is successful, then get() will return a value. if the load raised an exception, then get_exception() will return a value.
+    """A base class for preloading of resources via threads.
+    Calls to loading_function() are preloaded by load(), their results are cached, and are accessed via get().
+    this is useful for resources, where their loading is IO-bound and may hang the main thread, and which are not expected to change during the course of the program.
+    
+    To load a resource, call load() with the parameters to send to loading_function().
+        multiple separate resources may be loaded at once, identified by their parameter lists.
+    To retrieve a resource, call get() with the same parameters. only positional parameters are supported.
+    To wait upon a resource load without retrieving it, call wait().
+    Callbacks are also supported, as per register_callback().
+    
+    Preloading is done by a threadpool, and as such, many calls to load can be done in short succession without significant performance costs.
     """
     
     __metaclass__ = ABCMeta
     
-    def __init__(self):
+    def __init__(self, max_workers=None):
+        """
+        :parameter max_workers: (default None) The maximum number of preloading threads. default is min(32, available_cpu_count() + 4), taken from concurrent.futures.ThreadPoolExecutor
+        """
+        if max_workers is None: # ensure worker count is valid
+            try:
+                max_workers = min(32, available_cpu_count() + 4) # taken from concurrent.futures.ThreadPoolExecutor
+            except Exception: # On the offchance that cpu count fails, we don't actually care enough to raise an error about it. it may be treated as 1.
+                max_workers = 5 # 1 (failed cpu count) + 4
+        elif not isinstance(max_workers, int):
+            raise TypeError("max_workers is not an integral type!")
+        elif max_workers < 1:
+            raise ValueError("max_workers must be an a positive integer. number given: {}".format(int(max_workers)))
         
         # I haven't found any conclusive source on whether parallel reads and writes to different keys in dictionaries are thread-safe,
         #  So they're treated as unsafe.
-        self._loading_threads = {}
-        self._load_start_lock = threading.Lock()
+        self._job_queue = Queue()
+        self._loading_threads = []
+        for i in range(max_workers):
+            self._loading_threads.append(threading.Thread(target=self._manage_job_queue,
+                                                          name=u"Preload-o{}-{:02}".format(id(self), i)))
+            self._loading_threads[-1].daemon = True
+            self._loading_threads[-1].start()
         
         self._loaded_data = {}
         self._exception = {}
-        self._return_data_lock = threading.Lock() # Lock protecting dict access to the loaded data dictionaries: self._loaded_data and self._exception
+        self._callbacks = []
+        # A lock used both to keep the load data dicts sane, and to ensure all callbacks are called on the appropriate results.
+        self._load_data_lock = threading.Lock()
         
-        self._is_loaded = {}
+        
+        self._is_loaded = {} # Presence of a key here is used to detect if that said key is being loaded
         self._is_loaded_lock = threading.Lock()
         
         return
+    
+    def _manage_job_queue(self):
+        while True:
+            next_job = self._job_queue.get()
+            job_type = next_job[0]
+            if job_type is "load":
+                self._load_and_set(*next_job[1])
+            elif job_type is "callback":
+                new_callback, finished_loads = next_job[1], next_job[2]
+                self._call_callbacks(finished_loads, (new_callback,))
+            else:
+                raise ValueError("Unrecogised job of type: \"{}\"".format(job_type))
+    
     
     @abstractmethod
     def loading_function(self, *args):
         """Actually loads the required data.
         It may only take positional arguments, and return a single value: the loaded data, which will be accessible via the get() method.
-        It may raise an exception, in which case it'll be stored, and accessible via the get_exception() method.
+        It may raise an exception, in which case it'll be stored, and reraised by calls to the get() method.
+        This way, the result of the get() method will always be identical to the results of this method.
         """
         pass
     
     def _load_and_set(self, *args):
-        """Calls the _loading_function and sets the internal values based on its results."""
+        """Calls the _loading_function and stores it results for get()."""
         try:
             data = self.loading_function(*args)
-            with self._return_data_lock:
-                self._loaded_data[args] = data
-                self._exception[args] = None
+            exception = None
             print "Finished preload without errors"
         except Exception as e:
             print "Finished preload with errors of type={}".format(type(e))
-            with self._return_data_lock:
-                e.traceback = sys.exc_info()[2] # Adding traceback information to e
-                self._loaded_data[args] = None
-                self._exception[args] = e
+            data = None
+            exception = e
+            exception.traceback = sys.exc_info()[2]  # Adding traceback information to e
+        
+        with self._load_data_lock:
+            self._loaded_data[args] = data
+            self._exception[args] = exception
+            curr_callbacks = tuple(self._callbacks)
         
         with self._is_loaded_lock:
             self._is_loaded[args].set()
-        print "Done preloading"
+        # print "Done preloading"
+        self._call_callbacks((args,), curr_callbacks)
         return
     
     def load(self, *args):
-        """Starts preloading the data for args if it is not already being loaded.
-        This method starts a thread which loads the data.
-        It guarantees that for any number of repeated calls to it from any number of threads, only one loading thread will be started.
+        """Starts preloading the result of self.loading_function(*args) if it is not already being loaded.
+        It guarantees that for any number of repeated calls to it from any number of threads, self.loading_function() will only be called once for each distinct args.
         Once the data is loaded, it is available through the get() method.
         """
-        with self._load_start_lock:
-            # print "args={}, l_threads={}".format(args, self._loading_threads)
-            if args not in self._loading_threads:
-                print "Preload thread not present, Starting..."
-                with self._is_loaded_lock:
-                    self._is_loaded[args] = threading.Event()
-                self._loading_threads[args] = threading.Thread(target=self._load_and_set,
-                                                               name=u"Thread-load-{}-{}".format(self.__class__.__name__, hash(args)),
-                                                               args=args)
-                self._loading_threads[args].start()
-            else:
-                print "Preload thread already present"
-            return self._loading_threads[args]
+        with self._is_loaded_lock:
+            if args in self._is_loaded:
+                print "({}) Preload already present: {}".format(type(self).__name__, args)
+                return
+            
+            self._is_loaded[args] = threading.Event()
+        
+        print "({}) Preload not present, Starting... {}".format(type(self).__name__, args)
+        self._job_queue.put(("load", args))
+        return
     
     def get(self, *args, **kwargs):
-        """Get the preloaded data.
+        """Get the preloaded data corresponding to args.
         If the data has already loaded, this method returns with it immediately,
-        Otherwise, load() is called, and this method blocks using self.wait(timeout).
-        :returns steam modlist data, If timeout has not been reached and the loading thread has not raised an error.
+        Otherwise, load(*args) is called, and this method blocks using self.wait(*args, timeout=timeout).
+        :parameter timeout - name only (default None) - identical to self.wait() timeout parameter.
+        :returns preloaded result of self.loading_function(*args), If timeout has not been reached and the loading thread has not raised an error.
         :raises Exception, If timeout has not been reached and the loading thread has raised an error. this raises that very exception.
         :raises TimeoutError, If timeout has been reached.
         """
@@ -103,18 +306,49 @@ class PreloadBase:
             #  In that case the load() method has been called before and is currently finishing,
             #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
             
-            print "Preload data already available"
+            print "({}) Preload data already available: {}".format(type(self).__name__, args)
         else:
-            print "Preload data not available, calling load"
+            print "({}) Preload data not available, calling load: {}".format(type(self).__name__, args)
             self.load(*args)
             self.wait(*args, timeout=timeout)
-            print "Loading done, fetching data"
         
-        with self._return_data_lock:
-            if self._exception[args] is not None:
+        with self._load_data_lock:
+            if self._exception[args] is not None: # by this point, args must be present in both data dicts
                 raise self._exception[args]
             
             return self._loaded_data[args]
+    
+    
+    def register_callback(self, callback):
+        """Register a callback to be run on the result of each load when finished.
+        The callback will also be run on each already finished load.
+        A callback must receive two positional arguments: the result of the finished load, and the exception raised during it.
+        It is guaranteed that each callback will eventually run exactly once on each load.
+        """
+        
+        with self._load_data_lock:
+            self._callbacks.append(callback)
+            finised_loads = tuple(self._loaded_data.keys())
+        
+        self._job_queue.put(("callback", callback, finised_loads))
+        return
+    
+    def _call_callbacks(self, loads, callbacks):
+        """calls each callback in callbacks on each result of loads"""
+        for load_key in loads:
+            data = None
+            exception = None
+            try:
+                data = self.get(*load_key)
+            except Exception as e:
+                exception = e
+            for callback in callbacks:
+                try:
+                    callback(data, exception)
+                except Exception: # callback exceptions are ignored and do not affect other callbacks.
+                    pass
+        return
+    
     
     def is_loaded(self, *args):
         with self._is_loaded_lock:
@@ -122,6 +356,7 @@ class PreloadBase:
     
     def wait(self, *args, **kwargs):
         """Waits for timeout seconds until loading is finished. if timeout is None (default), waits indefinitely until loading is finished.
+        :parameter timeout - name only (default None) - the number of seconds to wait. by default - indefinitely.
         :returns None if loading is finished before timeout elapsed.
         :raises TimeoutError if timeout has expired before loading is finished."""
         if "timeout" in kwargs:

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -61,125 +61,6 @@ class Queue:
         self.get(False)
 
 
-# As we effectively use a threadpool for the preload class, we wish to access the cpu count of the machine to allow a logical default number of threads.
-#   multiprocessing (the standard way to check) is not available, so we use this one.
-# Source - https://stackoverflow.com/a/1006301
-# Posted by phihag, modified by community. See post 'Timeline' for change history
-# Retrieved 2026-04-07, License - CC BY-SA 4.0
-def available_cpu_count():
-    """ Number of available virtual or physical CPUs on this system, i.e.
-    user/real as output by time(1) when called with an optimally scaling
-    userspace-only program"""
-
-    # cpuset
-    # cpuset may restrict the number of *available* processors
-    try:
-        m = re.search(r'(?m)^Cpus_allowed:\s*(.*)$',
-                      open('/proc/self/status').read())
-        if m:
-            res = bin(int(m.group(1).replace(',', ''), 16)).count('1')
-            if res > 0:
-                return res
-    except IOError:
-        pass
-
-    # Python 2.6+
-    try:
-        import multiprocessing
-        return multiprocessing.cpu_count()
-    except (ImportError, NotImplementedError):
-        pass
-
-    # https://github.com/giampaolo/psutil
-    try:
-        import psutil
-        return psutil.cpu_count()   # psutil.NUM_CPUS on old versions
-    except (ImportError, AttributeError):
-        pass
-
-    # POSIX
-    try:
-        res = int(os.sysconf('SC_NPROCESSORS_ONLN'))
-
-        if res > 0:
-            return res
-    except (AttributeError, ValueError):
-        pass
-
-    # Windows
-    try:
-        res = int(os.environ['NUMBER_OF_PROCESSORS'])
-
-        if res > 0:
-            return res
-    except (KeyError, ValueError):
-        pass
-
-    # jython
-    try:
-        from java.lang import Runtime
-        runtime = Runtime.getRuntime()
-        res = runtime.availableProcessors()
-        if res > 0:
-            return res
-    except ImportError:
-        pass
-
-    # BSD
-    try:
-        sysctl = subprocess.Popen(['sysctl', '-n', 'hw.ncpu'],
-                                  stdout=subprocess.PIPE)
-        scStdout = sysctl.communicate()[0]
-        res = int(scStdout)
-
-        if res > 0:
-            return res
-    except (OSError, ValueError):
-        pass
-
-    # Linux
-    try:
-        res = open('/proc/cpuinfo').read().count('processor\t:')
-
-        if res > 0:
-            return res
-    except IOError:
-        pass
-
-    # Solaris
-    try:
-        pseudoDevices = os.listdir('/devices/pseudo/')
-        res = 0
-        for pd in pseudoDevices:
-            if re.match(r'^cpuid@[0-9]+$', pd):
-                res += 1
-
-        if res > 0:
-            return res
-    except OSError:
-        pass
-
-    # Other UNIXes (heuristic)
-    try:
-        try:
-            dmesg = open('/var/run/dmesg.boot').read()
-        except IOError:
-            dmesgProcess = subprocess.Popen(['dmesg'], stdout=subprocess.PIPE)
-            dmesg = dmesgProcess.communicate()[0]
-
-        res = 0
-        while '\ncpu' + str(res) + ':' in dmesg:
-            res += 1
-
-        if res > 0:
-            return res
-    except OSError:
-        pass
-
-    raise Exception('Can not determine number of CPUs on this system')
-
-
-
 class Preload:
     """A class for preloading of resources via threads.
     Calls to loading_function are grouped by parameter list and preloaded by load(). their results are cached, and are accessible via get().
@@ -195,7 +76,7 @@ class Preload:
     Preloading is done by a threadpool, and as such, many calls to load can be done in short succession without significant performance costs.
     """
     
-    def __init__(self, loading_function, max_workers=None):
+    def __init__(self, loading_function, max_workers=1):
         """
         :parameter loading_function: The function used to load the resource.
         :parameter max_workers: (default None) The maximum number of preloading threads. default is min(32, available_cpu_count() + 4), taken from concurrent.futures.ThreadPoolExecutor
@@ -204,15 +85,11 @@ class Preload:
         self._loading_function = loading_function
         self._name = self._loading_function.__name__ # Used for debugging
         
-        if max_workers is None: # ensure worker count is valid
-            try:
-                max_workers = min(32, available_cpu_count() + 4) # taken from concurrent.futures.ThreadPoolExecutor
-            except Exception: # On the offchance that cpu count fails, we don't actually care enough to raise an error about it. it may be treated as 1.
-                max_workers = 5 # 1 (failed cpu count) + 4
-        elif not isinstance(max_workers, int):
+        # ensure worker count is valid
+        if not isinstance(max_workers, int):
             raise TypeError("max_workers is not an integral type!")
         elif max_workers < 1:
-            raise ValueError("max_workers must be an a positive integer. number given: {}".format(int(max_workers)))
+            raise ValueError("max_workers must be an a positive integer. number given: {}".format(max_workers))
         
         # I haven't found any conclusive source on whether parallel reads and writes to different keys in dictionaries are thread-safe,
         #  So they're treated as unsafe.
@@ -309,10 +186,7 @@ class Preload:
         :raises TimeoutError, If timeout has been reached.
         :raises ClearingError, If a clear() call was preformed during this get() call
         """
-        if "timeout" in kwargs:
-            timeout = kwargs["timeout"]
-        else:
-            timeout = None
+        timeout = getattr(kwargs, "timeout", None)
         
         with self._clear_session_lock:
             start_session_num = self._clear_session_num
@@ -387,8 +261,8 @@ class Preload:
                     if not self._is_clear_session_valid(clear_session):
                         return # Once a clear session passes, this whole thing is invalidated
                     callback(data, exception)
-                except Exception: # callback exceptions are ignored and do not affect other callbacks.
-                    pass
+                except Exception as callback_exception: # callback exceptions are ignored and do not affect other callbacks.
+                    print "[] Callback {}({}, {}) raised exception: {}".format(self._name, callback, data, exception, callback_exception)
         return
     
     
@@ -404,10 +278,7 @@ class Preload:
         :raises KeyError if waiting upon a non-loading key.
         :raises TimeoutError if timeout has expired before loading is finished.
         :raises ClearingError if cleared during this wait (invalidation)."""
-        if "timeout" in kwargs:
-            timeout = kwargs["timeout"]
-        else:
-            timeout = None
+        timeout = getattr(kwargs, "timeout", None)
         
         with self._clear_session_lock:
             with self._is_loaded_lock:

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -5,7 +5,6 @@ import time
 import os
 import re
 import subprocess
-from abc import ABCMeta, abstractmethod
 
 
 class TimeoutError(Exception):
@@ -173,26 +172,30 @@ def available_cpu_count():
 
 
 
-class PreloadBase:
-    """A base class for preloading of resources via threads.
-    Calls to loading_function() are preloaded by load(), their results are cached, and are accessed via get().
+class Preload:
+    """A class for preloading of resources via threads.
+    Calls to loading_function are grouped by parameter list and preloaded by load(). their results are cached, and are accessible via get().
     this is useful for resources, where their loading is IO-bound and may hang the main thread, and which are not expected to change during the course of the program.
     
-    To load a resource, call load() with the parameters to send to loading_function().
+    To load a resource, call load() with the parameters to send to loading_function.
         multiple separate resources may be loaded at once, identified by their parameter lists.
-    To retrieve a resource, call get() with the same parameters. only positional parameters are supported.
+        only positional parameters are supported.
+    To retrieve a resource, call get() with the same parameters.
     To wait upon a resource load without retrieving it, call wait().
     Callbacks are also supported, as per register_callback().
     
     Preloading is done by a threadpool, and as such, many calls to load can be done in short succession without significant performance costs.
     """
     
-    __metaclass__ = ABCMeta
-    
-    def __init__(self, max_workers=None):
+    def __init__(self, loading_function, max_workers=None):
         """
+        :parameter loading_function: The function used to load the resource.
         :parameter max_workers: (default None) The maximum number of preloading threads. default is min(32, available_cpu_count() + 4), taken from concurrent.futures.ThreadPoolExecutor
         """
+        
+        self._loading_function = loading_function
+        self._name = self._loading_function.__name__ # Used for debugging
+        
         if max_workers is None: # ensure worker count is valid
             try:
                 max_workers = min(32, available_cpu_count() + 4) # taken from concurrent.futures.ThreadPoolExecutor
@@ -238,19 +241,10 @@ class PreloadBase:
                 raise ValueError("Unrecogised job of type: \"{}\"".format(job_type))
     
     
-    @abstractmethod
-    def loading_function(self, *args):
-        """Actually loads the required data.
-        It may only take positional arguments, and return a single value: the loaded data, which will be accessible via the get() method.
-        It may raise an exception, in which case it'll be stored, and reraised by calls to the get() method.
-        This way, the result of the get() method will always be identical to the results of this method.
-        """
-        pass
-    
     def _load_and_set(self, *args):
         """Calls the _loading_function and stores it results for get()."""
         try:
-            data = self.loading_function(*args)
+            data = self._loading_function(*args)
             exception = None
             print "Finished preload without errors"
         except Exception as e:
@@ -271,18 +265,18 @@ class PreloadBase:
         return
     
     def load(self, *args):
-        """Starts preloading the result of self.loading_function(*args) if it is not already being loaded.
-        It guarantees that for any number of repeated calls to it from any number of threads, self.loading_function() will only be called once for each distinct args.
+        """Starts preloading the result of loading_function(*args) if it is not already being loaded.
+        It guarantees that for any number of repeated calls to it from any number of threads, loading_function() will only be called once for each distinct args.
         Once the data is loaded, it is available through the get() method.
         """
         with self._is_loaded_lock:
             if args in self._is_loaded:
-                print "({}) Preload already present: {}".format(type(self).__name__, args)
+                print "({}) Preload already present: {}".format(self._name, args)
                 return
             
             self._is_loaded[args] = threading.Event()
         
-        print "({}) Preload not present, Starting... {}".format(type(self).__name__, args)
+        print "({}) Preload not present, Starting... {}".format(self._name, args)
         self._job_queue.put(("load", args))
         return
     
@@ -291,7 +285,7 @@ class PreloadBase:
         If the data has already loaded, this method returns with it immediately,
         Otherwise, load(*args) is called, and this method blocks using self.wait(*args, timeout=timeout).
         :parameter timeout - name only (default None) - identical to self.wait() timeout parameter.
-        :returns preloaded result of self.loading_function(*args), If timeout has not been reached and the loading thread has not raised an error.
+        :returns preloaded result of loading_function(*args), If timeout has not been reached and the loading thread has not raised an error.
         :raises Exception, If timeout has not been reached and the loading thread has raised an error. this raises that very exception.
         :raises TimeoutError, If timeout has been reached.
         """
@@ -306,9 +300,9 @@ class PreloadBase:
             #  In that case the load() method has been called before and is currently finishing,
             #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
             
-            print "({}) Preload data already available: {}".format(type(self).__name__, args)
+            print "({}) Preload data already available: {}".format(self._name, args)
         else:
-            print "({}) Preload data not available, calling load: {}".format(type(self).__name__, args)
+            print "({}) Preload data not available, calling load: {}".format(self._name, args)
             self.load(*args)
             self.wait(*args, timeout=timeout)
         

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -1,0 +1,138 @@
+import threading
+import sys
+from abc import ABCMeta, abstractmethod
+
+
+class TimeoutError(Exception):
+    """Represents a timeout for waiting for a load. mostly allows the timeout parameter in the get() method, to differentiate between a timeout and a failure."""
+    pass
+
+class PreloadBase:
+    """Manages the steam modlist, as is gotten by the steam_downloadable_mods method.
+    It supports loading the modlist in a separate thread via the load method,
+    And caching such results.
+    This is needed as loading the modlist takes quite a while,
+      And is an operation we would much rather do at startup, without delaying anything else.
+    Any exceptions raised in the loading process will be available through the get_exception() method.
+    Once the load finishes, Only one of the get() and get_exception() methods will return a value, while the other will return None.
+      If the load is successful, then get() will return a value. if the load raised an exception, then get_exception() will return a value.
+    """
+    
+    __metaclass__ = ABCMeta
+    
+    def __init__(self):
+        
+        # I haven't found any conclusive source on whether parallel reads and writes to different keys in dictionaries are thread-safe,
+        #  So they're treated as unsafe.
+        self._loading_threads = {}
+        self._load_start_lock = threading.Lock()
+        
+        self._loaded_data = {}
+        self._exception = {}
+        self._return_data_lock = threading.Lock() # Lock protecting dict access to the loaded data dictionaries: self._loaded_data and self._exception
+        
+        self._is_loaded = {}
+        self._is_loaded_lock = threading.Lock()
+        
+        return
+    
+    @abstractmethod
+    def loading_function(self, *args):
+        """Actually loads the required data.
+        It may only take positional arguments, and return a single value: the loaded data, which will be accessible via the get() method.
+        It may raise an exception, in which case it'll be stored, and accessible via the get_exception() method.
+        """
+        pass
+    
+    def _load_and_set(self, *args):
+        """Calls the _loading_function and sets the internal values based on its results."""
+        try:
+            data = self.loading_function(*args)
+            with self._return_data_lock:
+                self._loaded_data[args] = data
+                self._exception[args] = None
+            print "Finished preload without errors"
+        except Exception as e:
+            print "Finished preload with errors of type={}".format(type(e))
+            with self._return_data_lock:
+                e.traceback = sys.exc_info()[2] # Adding traceback information to e
+                self._loaded_data[args] = None
+                self._exception[args] = e
+        
+        with self._is_loaded_lock:
+            self._is_loaded[args].set()
+        print "Done preloading"
+        return
+    
+    def load(self, *args):
+        """Starts preloading the data for args if it is not already being loaded.
+        This method starts a thread which loads the data.
+        It guarantees that for any number of repeated calls to it from any number of threads, only one loading thread will be started.
+        Once the data is loaded, it is available through the get() method.
+        """
+        with self._load_start_lock:
+            # print "args={}, l_threads={}".format(args, self._loading_threads)
+            if args not in self._loading_threads:
+                print "Preload thread not present, Starting..."
+                with self._is_loaded_lock:
+                    self._is_loaded[args] = threading.Event()
+                self._loading_threads[args] = threading.Thread(target=self._load_and_set,
+                                                               name=u"Thread-load-{}-{}".format(self.__class__.__name__, hash(args)),
+                                                               args=args)
+                self._loading_threads[args].start()
+            else:
+                print "Preload thread already present"
+            return self._loading_threads[args]
+    
+    def get(self, *args, **kwargs):
+        """Get the preloaded data.
+        If the data has already loaded, this method returns with it immediately,
+        Otherwise, load() is called, and this method blocks using self.wait(timeout).
+        :returns steam modlist data, If timeout has not been reached and the loading thread has not raised an error.
+        :raises Exception, If timeout has not been reached and the loading thread has raised an error. this raises that very exception.
+        :raises TimeoutError, If timeout has been reached.
+        """
+        if "timeout" in kwargs:
+            timeout = kwargs["timeout"]
+        else:
+            timeout = None
+        
+        if self.is_loaded(*args):
+            # Note: while the value of is_loaded can change between checking it here and referring to _loaded_data,
+            #  It can only change from False to True.
+            #  In that case the load() method has been called before and is currently finishing,
+            #  And it'll be called again here, ignored, and _is_loaded will be waited upon, which will finish only once _loaded_data is available.
+            
+            print "Preload data already available"
+        else:
+            print "Preload data not available, calling load"
+            self.load(*args)
+            self.wait(*args, timeout=timeout)
+            print "Loading done, fetching data"
+        
+        with self._return_data_lock:
+            if self._exception[args] is not None:
+                raise self._exception[args]
+            
+            return self._loaded_data[args]
+    
+    def is_loaded(self, *args):
+        with self._is_loaded_lock:
+            return args in self._is_loaded and self._is_loaded[args].is_set()
+    
+    def wait(self, *args, **kwargs):
+        """Waits for timeout seconds until loading is finished. if timeout is None (default), waits indefinitely until loading is finished.
+        :returns None if loading is finished before timeout elapsed.
+        :raises TimeoutError if timeout has expired before loading is finished."""
+        if "timeout" in kwargs:
+            timeout = kwargs["timeout"]
+        else:
+            timeout = None
+        
+        with self._is_loaded_lock:
+            correct_is_done = self._is_loaded[args] # lock should only protect dict access and should never contain blocking actions.
+            
+        if not correct_is_done.wait(timeout):
+            raise TimeoutError(type(self).__name__)
+        return
+    

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -81,18 +81,36 @@ init python:
     import re
     import urllib2
 
+    from modloader.preload import PreloadBase
+
+    class ImageURLPreloader(PreloadBase):
+        def loading_function(self, url):
+            """
+            Loads the image data from given url. The resulting data is a str containing the image data
+            """
+            return urllib2.urlopen(url).read()
+
+    image_url_preloader = ImageURLPreloader()
+
+    import time
+    def _preload_mod_images(contents):
+        s_time = time.time()
+        image_urls = [entry[4] for entry in contents]
+        for url in image_urls:
+            image_url_preloader.load(url)
+        print "Preload load calls took: {}".format(time.time() - s_time)
+
     class ImageURL(Image):
         """
         This image manipulator loads an image from a url.
         """
         def load(self, unscaled=False):
-            import pygame
+#             import pygame
             from cStringIO import StringIO
-            from urllib2 import urlopen
+#             from urllib2 import urlopen
             from renpy.display.im import cache
 
-            url_f = urlopen(self.filename)
-            virtual_f = StringIO(url_f.read())
+            virtual_f = StringIO(image_url_preloader.get(self.filename))
 
             cache.add_load_log(self.filename)
             if unscaled:
@@ -304,7 +322,11 @@ screen modmenu_paged(contents, use_steam):
                         ]
                 sensitive (current_page < MAX_PAGE)
 
-    on "show" action Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam)
+    on "show" action [Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam),
+#                       Function(_preload_mod_images, contents)
+                      # Starting to preload ~60 mods caused a half-second delay in screen enter along with about 2 seconds of lag,
+                      #   Which is why preload images has been changed to by-page.
+                     ]
 
 
 
@@ -361,6 +383,8 @@ screen modmenu_paged_modlist(contents, use_steam):
                                  use_steam=use_steam,
                                  ),
                             Play("audio", "se/sounds/open.ogg")]
+    on "show" action [Function(_preload_mod_images, contents),
+                     ]
 
 
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -81,16 +81,15 @@ init python:
     import re
     import urllib2
 
-    from modloader.preload import PreloadBase
+    from modloader.preload import Preload
 
-    class ImageURLPreloader(PreloadBase):
-        def loading_function(self, url):
-            """
-            Loads the image data from given url. The resulting data is a str containing the image data
-            """
-            return urllib2.urlopen(url).read()
+    def load_mod_image(url):
+        """
+        Loads the image data from given url. The resulting data is a str containing the image data
+        """
+        return urllib2.urlopen(url).read()
 
-    image_url_preloader = ImageURLPreloader(5) # 5 threads is plenty
+    mod_image_preloader = Preload(load_mod_image, 5) # 5 threads is plenty
 
     def _preload_mod_images(modlist, error):
         if error is not None:
@@ -98,10 +97,11 @@ init python:
             return
         image_urls = [entry[4] for entry in modlist]
         for url in image_urls:
-            image_url_preloader.load(url)
+            mod_image_preloader.load(url)
         return
 
-    modconfig.steam_mod_list.register_callback(_preload_mod_images)
+    modconfig.steam_modlist_preloader.register_callback(_preload_mod_images)
+
 
     class ImageURL(Image):
         """
@@ -113,7 +113,7 @@ init python:
 #             from urllib2 import urlopen
             from renpy.display.im import cache
 
-            virtual_f = StringIO(image_url_preloader.get(self.filename))
+            virtual_f = StringIO(mod_image_preloader.get(self.filename))
 
             cache.add_load_log(self.filename)
             if unscaled:
@@ -154,7 +154,7 @@ init python:
 
     # Preload steam modlist, so we don't wait for it when we try to open the mod browser
     if internet_on() and modloader.has_steam():
-        modconfig.steam_mod_list.load()
+        modconfig.steam_modlist_preloader.load()
 
 
 init -1 python:
@@ -166,13 +166,13 @@ init -1 python:
 
 
     def is_modlist_loaded():
-        return modconfig.steam_mod_list.is_loaded()
+        return modconfig.steam_modlist_preloader.is_loaded()
 
     def _ensure_modlist_okay(strict=False):
         """Wait until the steam modlist is loaded, then check for errors and report any that have been detected.
         :parameter strict: default (False) only reports severe errors. if set to True, all errors are reported"""
         try:
-            modconfig.steam_mod_list.get()
+            modconfig.steam_modlist_preloader.get()
             return
         except steamhandler_extensions.CacheWriteError as exception:
             # CacheWriteError have a special error screen, as they're more severe

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -100,17 +100,13 @@ init python:
             mod_image_preloader.load(url)
         return
 
-#     modconfig.steam_modlist_preloader.register_callback(_preload_mod_images)
-
 
     class ImageURL(Image):
         """
         This image manipulator loads an image from a url.
         """
         def load(self, unscaled=False):
-#             import pygame
             from cStringIO import StringIO
-#             from urllib2 import urlopen
             from renpy.display.im import cache
 
             virtual_f = StringIO(mod_image_preloader.get(self.filename))

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -100,7 +100,7 @@ init python:
             mod_image_preloader.load(url)
         return
 
-    modconfig.steam_modlist_preloader.register_callback(_preload_mod_images)
+#     modconfig.steam_modlist_preloader.register_callback(_preload_mod_images)
 
 
     class ImageURL(Image):
@@ -325,7 +325,10 @@ screen modmenu_paged(contents, use_steam):
                         ]
                 sensitive (current_page < MAX_PAGE)
 
-    on "show" action [Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam)]
+    on "show" action [Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam),
+                      Function(_preload_mod_images, contents, None)]
+
+    on "hide" action [Function(mod_image_preloader.clear)]
 
 
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -90,15 +90,18 @@ init python:
             """
             return urllib2.urlopen(url).read()
 
-    image_url_preloader = ImageURLPreloader()
+    image_url_preloader = ImageURLPreloader(5) # 5 threads is plenty
 
-    import time
-    def _preload_mod_images(contents):
-        s_time = time.time()
-        image_urls = [entry[4] for entry in contents]
+    def _preload_mod_images(modlist, error):
+        if error is not None:
+            print "Definitely can't preload this..."
+            return
+        image_urls = [entry[4] for entry in modlist]
         for url in image_urls:
             image_url_preloader.load(url)
-        print "Preload load calls took: {}".format(time.time() - s_time)
+        return
+
+    modconfig.steam_mod_list.register_callback(_preload_mod_images)
 
     class ImageURL(Image):
         """
@@ -322,11 +325,7 @@ screen modmenu_paged(contents, use_steam):
                         ]
                 sensitive (current_page < MAX_PAGE)
 
-    on "show" action [Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam),
-#                       Function(_preload_mod_images, contents)
-                      # Starting to preload ~60 mods caused a half-second delay in screen enter along with about 2 seconds of lag,
-                      #   Which is why preload images has been changed to by-page.
-                     ]
+    on "show" action [Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam)]
 
 
 
@@ -383,8 +382,6 @@ screen modmenu_paged_modlist(contents, use_steam):
                                  use_steam=use_steam,
                                  ),
                             Play("audio", "se/sounds/open.ogg")]
-    on "show" action [Function(_preload_mod_images, contents),
-                     ]
 
 
 


### PR DESCRIPTION
The in-game mod browser shows the mod image of the selected mod. loading this image can generally take more than a second, which is incurred as a short freeze whenever a mod is selected from the mod list. As the delay is mainly caused by the loading of the image data from the internet, it can be avoided by preloading all image data ahead of time, then rendering the required images using that data. this is implemented in this request.

<img width="256" height="256" alt="Screenshot 2026-05-30 135723 modmenu image" src="https://github.com/user-attachments/assets/3182824c-2467-4f71-9464-7b47b34d6c71" />