### PR TITLE
Multi Install

### DIFF
--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -56,13 +56,13 @@ def report_exception(overview, error_str):
             #steammgr.HandleException(exception_str)
 
 
-def remove_mod(mod_name, filename):
+def remove_mod(mod_name, filename, reload_script=True):
     """Remove a mod from the game and reload.
 
     Args:
         mod_name (str): The internal name of the mod to be removed
     """
-    show_message("Removing mod {}...".format(mod_name))
+    # show_message("Removing mod {}...".format(mod_name))
     if filename is False:
         mod_class = get_mods()[mod_name]
         mod_folder = mod_class.__module__
@@ -74,11 +74,85 @@ def remove_mod(mod_name, filename):
         steammgr = steamhandler.get_instance()
         steammgr.Unsubscribe(int(mod_folder))
     shutil.rmtree(os.path.join(os.path.normpath(renpy.config.gamedir), "mods", mod_folder))
+    
+    if not reload_script:
+        print "Sucessfully removed {}".format(mod_name)
+        return
+    # else
     print "Sucessfully removed {}, reloading".format(mod_name)
     sys.stdout.flush()
-    show_message("Reloading game...")
+    # show_message("Reloading game...")
     _stop_music("modmenu_music")
     renpy.exports.reload_script()
+    return
+
+
+class ModmapInstallStatus:
+    """Holds the install status of a modmap install request in a thread-safe way."""
+    
+    def __init__(self, phase=False):
+        self._curr_mod_id = None
+        self._phase = phase
+        
+        self._lock = threading.RLock()
+    
+    def set_curr(self, mod_id):
+        with self._lock:
+            self._curr_mod_id = mod_id
+        return
+    
+    def get_curr(self):
+        with self._lock:
+            return self._curr_mod_id
+    
+    def set_phase(self, phase):
+        with self._lock:
+            self._phase = phase
+        return
+    
+    def get_phase(self):
+        with self._lock:
+            return self._phase
+
+
+def remove_mods(modmap, reload_script=True, show_status_screen=True):
+    """Remove all mods in the mod map modmap{mod_name: filename}
+    :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
+    """
+    print "remove_mods called with", modmap, reload_script, show_status_screen
+    if isinstance(show_status_screen, ModmapInstallStatus):
+        uninstall_status = show_status_screen
+    elif show_status_screen:
+        uninstall_status = ModmapInstallStatus(phase=True)
+        
+        for i in renpy.config.layers:
+            renpy.game.context().scene_lists.clear(i)
+        show_screen("_modloader_download_screen", uninstall_status, _layer="screens")
+    else:
+        uninstall_status = None
+    
+    thread_done_flag = threading.Event()
+    
+    def _uninstall_loop(modmap, reload_script, uninstall_status, thread_done_flag):
+        for mod_name, filename in modmap.iteritems():
+            if uninstall_status is not None:
+                uninstall_status.set_curr(mod_name)
+            remove_mod(mod_name, filename, reload_script=False)
+        
+        thread_done_flag.set()
+        
+        if reload_script:
+            restart_python()
+        
+        return
+    
+    threading.Thread(name="remove_mods__uninstall_loop", target=_uninstall_loop, args=(modmap, reload_script, uninstall_status, thread_done_flag)).start()
+    
+    if reload_script:
+        return None
+    else:
+        return thread_done_flag
+
 
 
 @cache
@@ -143,32 +217,15 @@ def download_github_mod(download_link, name, show_download=True, reload_script=T
     if reload_script:
         show_message("Reloading Game...")
         restart_python()
-    
 
-class ModmapInstallStatus:
-    """Holds the install status of a modmap install request in a thread-safe way."""
-    
-    def __init__(self):
-        self._curr_mod_id = None
-        
-        self._lock = threading.RLock()
-        
-    def set_curr(self, mod_id):
-        with self._lock:
-            self._curr_mod_id = mod_id
-        return
-    
-    def get_curr(self):
-        with self._lock:
-            return self._curr_mod_id
         
 
-def download_steam_mod(id, name, reload_script=True, show_install_screen=True):
+def download_steam_mod(id, name, reload_script=True, show_status_screen=True):
     """:returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions. """
     steammgr = steamhandler.get_instance()
     # (id, mod_name, author, desc, image_url)
-    if show_install_screen:
-        install_status = ModmapInstallStatus()
+    if show_status_screen:
+        install_status = ModmapInstallStatus(phase=False)
         install_status.set_curr(id)
         for i in renpy.config.layers:
             renpy.game.context().scene_lists.clear(i)
@@ -196,14 +253,16 @@ def download_steam_mod(id, name, reload_script=True, show_install_screen=True):
         return done_flag
 
 
-def download_steam_mods(modmap, reload_script=True, show_install_screen=True):
+def download_steam_mods(modmap, reload_script=True, show_status_screen=True):
     """Download all steam mods in the mod map modmap{modid: modname}
     :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
     """
     # steammgr = steamhandler.get_instance()
     # # (id, mod_name, author, desc, image_url)
-    if show_install_screen:
-        install_status = ModmapInstallStatus()
+    if isinstance(show_status_screen, ModmapInstallStatus):
+        install_status = show_status_screen
+    elif show_status_screen:
+        install_status = ModmapInstallStatus(phase=False)
         
         for i in renpy.config.layers:
             renpy.game.context().scene_lists.clear(i)
@@ -211,13 +270,13 @@ def download_steam_mods(modmap, reload_script=True, show_install_screen=True):
     else:
         install_status = None
     
-    done_flag = threading.Event()
+    thread_done_flag = threading.Event()
     
     def _install_loop(modmap, reload_script, install_status, thread_done_flag):
         for modid, modname in modmap.iteritems():
             if install_status is not None:
                 install_status.set_curr(modid)
-            mod_done_flag = download_steam_mod(modid, modname, reload_script=False, show_install_screen=False)
+            mod_done_flag = download_steam_mod(modid, modname, reload_script=False, show_status_screen=False)
             mod_done_flag.wait()
         
         thread_done_flag.set()
@@ -227,12 +286,52 @@ def download_steam_mods(modmap, reload_script=True, show_install_screen=True):
         
         return
     
-    threading.Thread(name="download_steam_mods__install_loop", target=_install_loop, args=(modmap, reload_script, install_status, done_flag)).start()
+    threading.Thread(name="download_steam_mods__install_loop", target=_install_loop, args=(modmap, reload_script, install_status, thread_done_flag)).start()
     
     if reload_script:
         return None
     else:
-        return done_flag
+        return thread_done_flag
+
+
+
+def apply_mod_changes(add_modmap, remove_modmap, reload_script=True, show_status_screen=True):
+    """
+    :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
+    """
+    print "apply_mod_changes called with", add_modmap, remove_modmap, reload_script, show_status_screen
+    if show_status_screen:
+        print "screen should be shown!"
+        apply_status = ModmapInstallStatus(phase=False)
+        
+        for i in renpy.config.layers:
+            renpy.game.context().scene_lists.clear(i)
+        show_screen("_modloader_download_screen", apply_status, _layer="screens")
+    else:
+        apply_status = None
+    
+    thread_done_flag = threading.Event()
+    
+    def _apply_loop(add_modmap, remove_modmap, reload_script, apply_status, thread_done_flag):
+        download_steam_mods(add_modmap, reload_script=False, show_status_screen=apply_status).wait()
+        apply_status.set_curr(None)
+        apply_status.set_phase(True)
+        remove_mods(remove_modmap, reload_script=False, show_status_screen=apply_status).wait()
+        
+        apply_status.set_curr(None)
+        thread_done_flag.set()
+        
+        if reload_script:
+            restart_python()
+        
+        return
+    
+    threading.Thread(name="apply_mod_changes__apply_loop", target=_apply_loop, args=(add_modmap, remove_modmap, reload_script, apply_status, thread_done_flag)).start()
+    
+    if reload_script:
+        return None
+    else:
+        return thread_done_flag
 
 
 

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -107,11 +107,16 @@ def steam_downloadable_mods():
 class ModmapInstallStatus:
     """Holds the install status of a modmap install request in a thread-safe way."""
     
-    def __init__(self, phase=False):
+    def __init__(self, phase=False, use_steam=True):
         self._curr_mod_id = None
         self._phase = phase
+        self._use_steam = use_steam
         
         self._lock = threading.RLock()
+    
+    # as this is treated as the source of this mod suite, we (currently) don't expect it to change during the suite.
+    def use_steam(self):
+        return self._use_steam
     
     def set_curr(self, mod_id):
         with self._lock:
@@ -153,13 +158,6 @@ def remove_mod(mod_name, filename):
     
     print "Sucessfully removed {}".format(mod_name)
     return
-    # else
-    # print "Sucessfully removed {}, reloading".format(mod_name)
-    # sys.stdout.flush()
-    # # show_message("Reloading game...")
-    # _stop_music("modmenu_music")
-    # renpy.exports.reload_script()
-    # return
 
 
 def remove_mods(modmap, install_status=None):
@@ -182,11 +180,12 @@ def remove_mods(modmap, install_status=None):
 
 
 
+def download_github_mod(download_link, name):
+    """Download a mod off the Github standard mod repository by its link and name.
 
-
-def download_github_mod(download_link, name, show_download=True, reload_script=True):
-    if show_download:
-        show_message("Downloading {}".format(name))
+    :param download_link: The github archive link of the mod.
+    :param name: The name of the mod to install. this is also the name (path relative to general mod installation path) of the destination directory.
+    """
     mod_folder = os.path.join(get_mod_path(), name)
     if os.path.exists(mod_folder):
         shutil.rmtree(mod_folder, ignore_errors=True)
@@ -196,10 +195,7 @@ def download_github_mod(download_link, name, show_download=True, reload_script=T
     root = zip_f.namelist()[0]
     os.rename(os.path.join(get_mod_path(), root),
               mod_folder)
-    if reload_script:
-        show_message("Reloading Game...")
-        restart_python()
-
+    return
 
 def download_steam_mod(id, name):
     """Download a mod off the Steam workshop based on its id.
@@ -228,35 +224,40 @@ def download_steam_mod(id, name):
     return
 
 
-def download_steam_mods(modmap, install_status=None):
-    """Download all steam mods in modmap, optionally while supplying status data.
-    
-    :param modmap: Mapping from modid to modname, as they are in download_steam_mod. the modlist to install.
+def download_github_mods(modmap, install_status=None):
+    """Download all github mods in modmap, optionally while supplying status data.
+
+    :param modmap: Mapping from modurl to modname, as they are in download_github_mod. the modlist to install.
     :param install_status: If not None, the ModmapInstallStatus instance used to show current progress.
-    :returns: A threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
     """
     if install_status is not None:
         install_status.set_phase(False)
     
-    thread_done_flag = threading.Event()
+    for modid, modname in modmap.iteritems():
+        if install_status is not None:
+            install_status.set_curr(modid)
+        download_github_mod(modid, modname)
     
-    def _install_loop(modmap, install_status, thread_done_flag):
-        for modid, modname in modmap.iteritems():
-            if install_status is not None:
-                install_status.set_curr(modid)
-            mod_done_flag = download_steam_mod(modid, modname)
-            mod_done_flag.wait()
-        
-        thread_done_flag.set()
-        return
+    return
+
+def download_steam_mods(modmap, install_status=None):
+    """Download all steam mods in modmap, optionally while supplying status data.
+
+    :param modmap: Mapping from modid to modname, as they are in download_steam_mod. the modlist to install.
+    :param install_status: If not None, the ModmapInstallStatus instance used to show current progress.
+    """
+    if install_status is not None:
+        install_status.set_phase(False)
     
-    threading.Thread(name="download_steam_mods__install_loop", target=_install_loop, args=(modmap, install_status, thread_done_flag)).start()
+    for modid, modname in modmap.iteritems():
+        if install_status is not None:
+            install_status.set_curr(modid)
+        download_steam_mod(modid, modname)
     
-    return thread_done_flag
+    return
 
 
-
-def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload_script=None):
+def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload_script=None, use_steam=True):
     """ Apply the mod changes given in the modlists, optionally showing the mod status screen and reloading when done.
     
     This acts as the main way to visibly apple a suite of mod changes, and should be the one used in most cases.
@@ -264,15 +265,15 @@ def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload
     :param remove_modmap: Mapping from modname to filename, as they are in remove_mod. the modlist to remove.
     :param show_status_screen: If True, then show the mod changes status screen.
     :param reload_script: If True, then restart the script once the mod changes are done. If None (the default), this is set to the value of show_status_screen.
+    :param use_steam: True (default) uses steam api to install the mods. False uses github api.
     :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
     """
     if reload_script is None:
         reload_script = show_status_screen
     
-    print "apply_mod_changes called with", add_modmap, remove_modmap, reload_script, show_status_screen
+    print "apply_mod_changes called with", add_modmap, remove_modmap, reload_script, show_status_screen, use_steam
     if show_status_screen:
-        print "screen should be shown!"
-        apply_status = ModmapInstallStatus(phase=False)
+        apply_status = ModmapInstallStatus(phase=False, use_steam=use_steam)
         
         for i in renpy.config.layers:
             renpy.game.context().scene_lists.clear(i)
@@ -283,7 +284,11 @@ def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload
     thread_done_flag = threading.Event()
     
     def _apply_loop(add_modmap, remove_modmap, reload_script, apply_status, thread_done_flag):
-        download_steam_mods(add_modmap, install_status=apply_status)
+        if use_steam:
+            download_steam_mods(add_modmap, install_status=apply_status)
+        else:
+            download_github_mods(add_modmap, install_status=apply_status)
+        
         if apply_status is not None:
             apply_status.set_curr(None)
             apply_status.set_phase(True)

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -56,104 +56,6 @@ def report_exception(overview, error_str):
             #steammgr.HandleException(exception_str)
 
 
-def remove_mod(mod_name, filename, reload_script=True):
-    """Remove a mod from the game and reload.
-
-    Args:
-        mod_name (str): The internal name of the mod to be removed
-    """
-    # show_message("Removing mod {}...".format(mod_name))
-    if filename is False:
-        mod_class = get_mods()[mod_name]
-        mod_folder = mod_class.__module__
-    elif filename is True:
-        mod_folder = mod_name
-    else:
-        mod_folder = filename
-    if mod_folder.isdigit():
-        steammgr = steamhandler.get_instance()
-        steammgr.Unsubscribe(int(mod_folder))
-    shutil.rmtree(os.path.join(os.path.normpath(renpy.config.gamedir), "mods", mod_folder))
-    
-    if not reload_script:
-        print "Sucessfully removed {}".format(mod_name)
-        return
-    # else
-    print "Sucessfully removed {}, reloading".format(mod_name)
-    sys.stdout.flush()
-    # show_message("Reloading game...")
-    _stop_music("modmenu_music")
-    renpy.exports.reload_script()
-    return
-
-
-class ModmapInstallStatus:
-    """Holds the install status of a modmap install request in a thread-safe way."""
-    
-    def __init__(self, phase=False):
-        self._curr_mod_id = None
-        self._phase = phase
-        
-        self._lock = threading.RLock()
-    
-    def set_curr(self, mod_id):
-        with self._lock:
-            self._curr_mod_id = mod_id
-        return
-    
-    def get_curr(self):
-        with self._lock:
-            return self._curr_mod_id
-    
-    def set_phase(self, phase):
-        with self._lock:
-            self._phase = phase
-        return
-    
-    def get_phase(self):
-        with self._lock:
-            return self._phase
-
-
-def remove_mods(modmap, reload_script=True, show_status_screen=True):
-    """Remove all mods in the mod map modmap{mod_name: filename}
-    :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
-    """
-    print "remove_mods called with", modmap, reload_script, show_status_screen
-    if isinstance(show_status_screen, ModmapInstallStatus):
-        uninstall_status = show_status_screen
-    elif show_status_screen:
-        uninstall_status = ModmapInstallStatus(phase=True)
-        
-        for i in renpy.config.layers:
-            renpy.game.context().scene_lists.clear(i)
-        show_screen("_modloader_download_screen", uninstall_status, _layer="screens")
-    else:
-        uninstall_status = None
-    
-    thread_done_flag = threading.Event()
-    
-    def _uninstall_loop(modmap, reload_script, uninstall_status, thread_done_flag):
-        for mod_name, filename in modmap.iteritems():
-            if uninstall_status is not None:
-                uninstall_status.set_curr(mod_name)
-            remove_mod(mod_name, filename, reload_script=False)
-        
-        thread_done_flag.set()
-        
-        if reload_script:
-            restart_python()
-        
-        return
-    
-    threading.Thread(name="remove_mods__uninstall_loop", target=_uninstall_loop, args=(modmap, reload_script, uninstall_status, thread_done_flag)).start()
-    
-    if reload_script:
-        return None
-    else:
-        return thread_done_flag
-
-
 
 @cache
 def github_downloadable_mods():
@@ -202,6 +104,86 @@ def steam_downloadable_mods():
     return steam_modlist_preloader.get()
 
 
+class ModmapInstallStatus:
+    """Holds the install status of a modmap install request in a thread-safe way."""
+    
+    def __init__(self, phase=False):
+        self._curr_mod_id = None
+        self._phase = phase
+        
+        self._lock = threading.RLock()
+    
+    def set_curr(self, mod_id):
+        with self._lock:
+            self._curr_mod_id = mod_id
+        return
+    
+    def get_curr(self):
+        with self._lock:
+            return self._curr_mod_id
+    
+    def set_phase(self, phase):
+        with self._lock:
+            self._phase = phase
+        return
+    
+    def get_phase(self):
+        with self._lock:
+            return self._phase
+
+
+def remove_mod(mod_name, filename):
+    """Remove a mod from the game and reload.
+    
+    :param mod_name: The name of the mod to be removed, as a string.
+    :param filename: If True, mod_name is the path of the mod to be removed. If False, the path is taken from the mod's modclass. If a string, the path of the mod to be removed.
+    """
+    # show_message("Removing mod {}...".format(mod_name))
+    if filename is False:
+        mod_class = get_mods()[mod_name]
+        mod_folder = mod_class.__module__
+    elif filename is True:
+        mod_folder = mod_name
+    else:
+        mod_folder = filename
+    if mod_folder.isdigit():
+        steammgr = steamhandler.get_instance()
+        steammgr.Unsubscribe(int(mod_folder))
+    shutil.rmtree(os.path.join(os.path.normpath(renpy.config.gamedir), "mods", mod_folder))
+    
+    print "Sucessfully removed {}".format(mod_name)
+    return
+    # else
+    # print "Sucessfully removed {}, reloading".format(mod_name)
+    # sys.stdout.flush()
+    # # show_message("Reloading game...")
+    # _stop_music("modmenu_music")
+    # renpy.exports.reload_script()
+    # return
+
+
+def remove_mods(modmap, install_status=None):
+    """Remove all mods in modmap, optionally while supplying status data.
+    
+    :param modmap: Mapping from modname to filename, as they are in remove_mod. the modlist to remove.
+    :param install_status: If not None, the ModmapInstallStatus instance used to show current progress.
+    """
+    print "remove_mods called with", modmap, install_status
+    
+    if install_status is not None:
+        install_status.set_phase(True)
+    
+    for mod_name, filename in modmap.iteritems():
+        if install_status is not None:
+            install_status.set_curr(mod_name)
+        remove_mod(mod_name, filename)
+    
+    return
+
+
+
+
+
 def download_github_mod(download_link, name, show_download=True, reload_script=True):
     if show_download:
         show_message("Downloading {}".format(name))
@@ -218,19 +200,15 @@ def download_github_mod(download_link, name, show_download=True, reload_script=T
         show_message("Reloading Game...")
         restart_python()
 
-        
 
-def download_steam_mod(id, name, reload_script=True, show_status_screen=True):
-    """:returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions. """
+def download_steam_mod(id, name):
+    """Download a mod off the Steam workshop based on its id.
+    
+    :param id: The Steam ID of the mod to install.
+    :param name: The name of the mod to install. this parameter is ignored, and is there to match the interface of the github install calls.
+    """
     steammgr = steamhandler.get_instance()
     # (id, mod_name, author, desc, image_url)
-    if show_status_screen:
-        install_status = ModmapInstallStatus(phase=False)
-        install_status.set_curr(id)
-        for i in renpy.config.layers:
-            renpy.game.context().scene_lists.clear(i)
-        show_screen("_modloader_download_screen", install_status, _layer="screens")
-
     done_flag = threading.Event()
     
     def cb(item, success):
@@ -241,64 +219,56 @@ def download_steam_mod(id, name, reload_script=True, show_status_screen=True):
 
         steammgr.unregister_callback(steamhandler.PyCallback.Download, cb)
         done_flag.set()
-        if reload_script:
-            restart_python()
-    
+        return
+        
     steammgr.register_callback(steamhandler.PyCallback.Download, cb)
     steammgr.Subscribe(id)
     
-    if reload_script:
-        return None
-    else:
-        return done_flag
+    done_flag.wait()
+    return
 
 
-def download_steam_mods(modmap, reload_script=True, show_status_screen=True):
-    """Download all steam mods in the mod map modmap{modid: modname}
-    :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
+def download_steam_mods(modmap, install_status=None):
+    """Download all steam mods in modmap, optionally while supplying status data.
+    
+    :param modmap: Mapping from modid to modname, as they are in download_steam_mod. the modlist to install.
+    :param install_status: If not None, the ModmapInstallStatus instance used to show current progress.
+    :returns: A threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
     """
-    # steammgr = steamhandler.get_instance()
-    # # (id, mod_name, author, desc, image_url)
-    if isinstance(show_status_screen, ModmapInstallStatus):
-        install_status = show_status_screen
-    elif show_status_screen:
-        install_status = ModmapInstallStatus(phase=False)
-        
-        for i in renpy.config.layers:
-            renpy.game.context().scene_lists.clear(i)
-        show_screen("_modloader_download_screen", install_status, _layer="screens")
-    else:
-        install_status = None
+    if install_status is not None:
+        install_status.set_phase(False)
     
     thread_done_flag = threading.Event()
     
-    def _install_loop(modmap, reload_script, install_status, thread_done_flag):
+    def _install_loop(modmap, install_status, thread_done_flag):
         for modid, modname in modmap.iteritems():
             if install_status is not None:
                 install_status.set_curr(modid)
-            mod_done_flag = download_steam_mod(modid, modname, reload_script=False, show_status_screen=False)
+            mod_done_flag = download_steam_mod(modid, modname)
             mod_done_flag.wait()
         
         thread_done_flag.set()
-        
-        if reload_script:
-            restart_python()
-        
         return
     
-    threading.Thread(name="download_steam_mods__install_loop", target=_install_loop, args=(modmap, reload_script, install_status, thread_done_flag)).start()
+    threading.Thread(name="download_steam_mods__install_loop", target=_install_loop, args=(modmap, install_status, thread_done_flag)).start()
     
-    if reload_script:
-        return None
-    else:
-        return thread_done_flag
+    return thread_done_flag
 
 
 
-def apply_mod_changes(add_modmap, remove_modmap, reload_script=True, show_status_screen=True):
-    """
+def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload_script=None):
+    """ Apply the mod changes given in the modlists, optionally showing the mod status screen and reloading when done.
+    
+    This acts as the main way to visibly apple a suite of mod changes, and should be the one used in most cases.
+    :param add_modmap: Mapping from modid to modname, as they are in download_steam_mod. the modlist to install.
+    :param remove_modmap: Mapping from modname to filename, as they are in remove_mod. the modlist to remove.
+    :param show_status_screen: If True, then show the mod changes status screen.
+    :param reload_script: If True, then restart the script once the mod changes are done. If None (the default), this is set to the value of show_status_screen.
     :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
     """
+    if reload_script is None:
+        reload_script = show_status_screen
+    
     print "apply_mod_changes called with", add_modmap, remove_modmap, reload_script, show_status_screen
     if show_status_screen:
         print "screen should be shown!"
@@ -313,12 +283,14 @@ def apply_mod_changes(add_modmap, remove_modmap, reload_script=True, show_status
     thread_done_flag = threading.Event()
     
     def _apply_loop(add_modmap, remove_modmap, reload_script, apply_status, thread_done_flag):
-        download_steam_mods(add_modmap, reload_script=False, show_status_screen=apply_status).wait()
-        apply_status.set_curr(None)
-        apply_status.set_phase(True)
-        remove_mods(remove_modmap, reload_script=False, show_status_screen=apply_status).wait()
+        download_steam_mods(add_modmap, install_status=apply_status)
+        if apply_status is not None:
+            apply_status.set_curr(None)
+            apply_status.set_phase(True)
+        remove_mods(remove_modmap, install_status=apply_status)
         
-        apply_status.set_curr(None)
+        if apply_status is not None:
+            apply_status.set_curr(None)
         thread_done_flag.set()
         
         if reload_script:

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -251,8 +251,8 @@ def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload
     This acts as the main way to visibly apple a suite of mod changes, and should be the one used in most cases.
     :param add_modmap: Mapping from modid to modname, as they are in download_steam_mod. the modlist to install.
     :param remove_modmap: Mapping from modname to filename, as they are in remove_mod. the modlist to remove.
-    :param show_status_screen: If True, then show the mod changes status screen.
-    :param reload_script: If True, then restart the script once the mod changes are done. If None (the default), this is set to the value of show_status_screen.
+    :param show_status_screen: If True (default), then show the mod changes status screen. If False, doesn't show the mod changes status screen.
+    :param reload_script: If True, then restart the script once the mod changes are done. If False, no restarting is done. If None (the default), this is set to the value of show_status_screen which allows for 'install visibly then restart' and 'install silently'.
     :param use_steam: True (default) uses steam api to install the mods. False uses github api.
     :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
     """

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -121,7 +121,6 @@ class ModmapInstallStatus:
     def set_curr(self, mod_id):
         with self._lock:
             self._curr_mod_id = mod_id
-        return
     
     def get_curr(self):
         with self._lock:
@@ -130,7 +129,6 @@ class ModmapInstallStatus:
     def set_phase(self, phase):
         with self._lock:
             self._phase = phase
-        return
     
     def get_phase(self):
         with self._lock:
@@ -157,7 +155,6 @@ def remove_mod(mod_name, filename):
     shutil.rmtree(os.path.join(os.path.normpath(renpy.config.gamedir), "mods", mod_folder))
     
     print "Sucessfully removed {}".format(mod_name)
-    return
 
 
 def remove_mods(modmap, install_status=None):
@@ -175,8 +172,6 @@ def remove_mods(modmap, install_status=None):
         if install_status is not None:
             install_status.set_curr(mod_name)
         remove_mod(mod_name, filename)
-    
-    return
 
 
 
@@ -195,7 +190,6 @@ def download_github_mod(download_link, name):
     root = zip_f.namelist()[0]
     os.rename(os.path.join(get_mod_path(), root),
               mod_folder)
-    return
 
 def download_steam_mod(id, name):
     """Download a mod off the Steam workshop based on its id.
@@ -215,13 +209,11 @@ def download_steam_mod(id, name):
 
         steammgr.unregister_callback(steamhandler.PyCallback.Download, cb)
         done_flag.set()
-        return
         
     steammgr.register_callback(steamhandler.PyCallback.Download, cb)
     steammgr.Subscribe(id)
     
     done_flag.wait()
-    return
 
 
 def download_github_mods(modmap, install_status=None):
@@ -238,8 +230,6 @@ def download_github_mods(modmap, install_status=None):
             install_status.set_curr(modid)
         download_github_mod(modid, modname)
     
-    return
-
 def download_steam_mods(modmap, install_status=None):
     """Download all steam mods in modmap, optionally while supplying status data.
 
@@ -253,8 +243,6 @@ def download_steam_mods(modmap, install_status=None):
         if install_status is not None:
             install_status.set_curr(modid)
         download_steam_mod(modid, modname)
-    
-    return
 
 
 def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload_script=None, use_steam=True):
@@ -300,8 +288,6 @@ def apply_mod_changes(add_modmap, remove_modmap, show_status_screen=True, reload
         
         if reload_script:
             restart_python()
-        
-        return
     
     threading.Thread(name="apply_mod_changes__apply_loop", target=_apply_loop, args=(add_modmap, remove_modmap, reload_script, apply_status, thread_done_flag)).start()
     

--- a/modloader/modconfig.py
+++ b/modloader/modconfig.py
@@ -3,6 +3,7 @@ import sys
 import os
 
 import subprocess
+import threading
 import shutil
 from urllib2 import urlopen
 import json
@@ -144,12 +145,36 @@ def download_github_mod(download_link, name, show_download=True, reload_script=T
         restart_python()
     
 
-def download_steam_mod(id, name, reload_script=True):
+class ModmapInstallStatus:
+    """Holds the install status of a modmap install request in a thread-safe way."""
+    
+    def __init__(self):
+        self._curr_mod_id = None
+        
+        self._lock = threading.RLock()
+        
+    def set_curr(self, mod_id):
+        with self._lock:
+            self._curr_mod_id = mod_id
+        return
+    
+    def get_curr(self):
+        with self._lock:
+            return self._curr_mod_id
+        
+
+def download_steam_mod(id, name, reload_script=True, show_install_screen=True):
+    """:returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions. """
     steammgr = steamhandler.get_instance()
     # (id, mod_name, author, desc, image_url)
-    for i in renpy.config.layers:
-        renpy.game.context().scene_lists.clear(i)
-    show_screen("_modloader_download_screen", id, _layer="screens")
+    if show_install_screen:
+        install_status = ModmapInstallStatus()
+        install_status.set_curr(id)
+        for i in renpy.config.layers:
+            renpy.game.context().scene_lists.clear(i)
+        show_screen("_modloader_download_screen", install_status, _layer="screens")
+
+    done_flag = threading.Event()
     
     def cb(item, success):
         # Copy the folder
@@ -158,11 +183,58 @@ def download_steam_mod(id, name, reload_script=True):
         shutil.copytree(src, dest)
 
         steammgr.unregister_callback(steamhandler.PyCallback.Download, cb)
+        done_flag.set()
         if reload_script:
             restart_python()
     
     steammgr.register_callback(steamhandler.PyCallback.Download, cb)
     steammgr.Subscribe(id)
+    
+    if reload_script:
+        return None
+    else:
+        return done_flag
+
+
+def download_steam_mods(modmap, reload_script=True, show_install_screen=True):
+    """Download all steam mods in the mod map modmap{modid: modname}
+    :returns: done_flag if reload_script is False, else None. done_flag is a threading.Event which becomes set once the mod is installed. note that this return value can end interactions.
+    """
+    # steammgr = steamhandler.get_instance()
+    # # (id, mod_name, author, desc, image_url)
+    if show_install_screen:
+        install_status = ModmapInstallStatus()
+        
+        for i in renpy.config.layers:
+            renpy.game.context().scene_lists.clear(i)
+        show_screen("_modloader_download_screen", install_status, _layer="screens")
+    else:
+        install_status = None
+    
+    done_flag = threading.Event()
+    
+    def _install_loop(modmap, reload_script, install_status, thread_done_flag):
+        for modid, modname in modmap.iteritems():
+            if install_status is not None:
+                install_status.set_curr(modid)
+            mod_done_flag = download_steam_mod(modid, modname, reload_script=False, show_install_screen=False)
+            mod_done_flag.wait()
+        
+        thread_done_flag.set()
+        
+        if reload_script:
+            restart_python()
+        
+        return
+    
+    threading.Thread(name="download_steam_mods__install_loop", target=_install_loop, args=(modmap, reload_script, install_status, done_flag)).start()
+    
+    if reload_script:
+        return None
+    else:
+        return done_flag
+
+
 
 
 class UpdateModtools(Action):

--- a/modloader/preload.py
+++ b/modloader/preload.py
@@ -25,14 +25,12 @@ class Queue:
     def __init__(self):
         self._queue = collections.deque()
         self._pop_condition = threading.Condition()
-        return
     
     
     def put(self, item):
         with self._pop_condition:
             self._queue.append(item)
             self._pop_condition.notify()
-        return
     
     def get(self, block=True, timeout=None):
         if not block or timeout == 0: # For these non-blocking cases, We avoid the retrying located below.
@@ -55,7 +53,6 @@ class Queue:
     
     def clear(self):
         self._queue.clear()
-        return
     
     def get_nowait(self):
         self.get(False)
@@ -113,8 +110,7 @@ class Preload:
         
         self._clear_session_num = 0 # clear() uses session numbers to ensure that once clear is called, all ongoing actions are invalidated
         self._clear_session_lock = threading.RLock()
-        
-        return
+    
     
     def _manage_job_queue(self):
         while True:
@@ -157,7 +153,7 @@ class Preload:
                 self._is_loaded[args].set()
             # print "Done preloading"
             self._call_callbacks((args,), curr_callbacks, clear_session=self._clear_session_num)
-        return
+    
     
     def load(self, *args):
         """Starts preloading the result of loading_function(*args) if it is not already being loaded.
@@ -174,7 +170,7 @@ class Preload:
             
             print "({}) Preload not present, Starting... {}".format(self._name, args)
             self._job_queue.put((self._clear_session_num, "load", args))
-        return
+    
     
     def get(self, *args, **kwargs):
         """Get the preloaded data corresponding to args.
@@ -222,7 +218,7 @@ class Preload:
             self._exception.clear()
             self._is_loaded.clear()
             self._job_queue.clear()
-            return
+        
     
     def _is_clear_session_valid(self, clear_session):
         with self._clear_session_lock:
@@ -242,7 +238,7 @@ class Preload:
                 finised_loads = tuple(self._loaded_data.keys())
         
             self._job_queue.put((self._clear_session_num, "callback", callback, finised_loads))
-        return
+        
     
     def _call_callbacks(self, loads, callbacks, clear_session):
         """calls each callback in callbacks on each result of loads"""
@@ -263,7 +259,7 @@ class Preload:
                     callback(data, exception)
                 except Exception as callback_exception: # callback exceptions are ignored and do not affect other callbacks.
                     print "[] Callback {}({}, {}) raised exception: {}".format(self._name, callback, data, exception, callback_exception)
-        return
+        
     
     
     def is_loaded(self, *args):

--- a/modloader/steamhandler_extensions.py
+++ b/modloader/steamhandler_extensions.py
@@ -156,8 +156,7 @@ class CachedSteamMgr:
             finally:
                 print "Cache file write callback done (page {}).".format(page)
                 fill_cache_query_cb.done.set()
-            
-            return
+        
         
         fill_cache_query_cb.error = None
         self.register_callback(PyCallback.Query, fill_cache_query_cb)
@@ -172,9 +171,6 @@ class CachedSteamMgr:
             
             if fill_cache_query_cb.error is not None:
                 raise fill_cache_query_cb.error
-            
-            return
-        
         finally:
             self.unregister_callback(PyCallback.Query, fill_cache_query_cb)
     
@@ -284,7 +280,6 @@ class CachedSteamMgr:
             
             cb.should_run_next = (arr_len == 50)
             cb.page_complete.set()
-            return
         
         cb.page_num = 1
         cb.should_run_next = True

--- a/mods/core/core.rpy
+++ b/mods/core/core.rpy
@@ -46,7 +46,7 @@ screen modmenu tag smallscreen:
             #mod management buttons
             vbox xalign 0.5 yalign 0.5:
                 if has_steam():
-                    textbutton "Add mod from workshop":
+                    textbutton "Manage workshop mods":
                         action [Function(_enter_modmenu, use_steam=True),
                                 Play("audio", "se/sounds/open.ogg"),
                                 Stop("music", fadeout=1.0),
@@ -56,7 +56,7 @@ screen modmenu tag smallscreen:
                         style "menubutton2"
 
                 if is_github():
-                    textbutton "Add mod from Github":
+                    textbutton "Manage Github mods":
                         action [Function(_enter_modmenu, use_steam=False),
                                 Play("audio", "se/sounds/open.ogg"),
                                 Stop("music", fadeout=1.0),

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -383,6 +383,38 @@ init -1 python:
         return
 
 
+    _modmenu_mods_to_add = {}
+    _modmenu_mods_to_remove = set()
+
+    def _modmenu_add_mod(mod_id, mod_name):
+        print "adding mod:", mod_id, mod_name
+        if mod_id in _modmenu_mods_to_remove:
+            _modmenu_mods_to_remove.discard(mod_id)
+        else:
+            _modmenu_mods_to_add[mod_id] = mod_name
+        return
+
+    def _modmenu_remove_mod(mod_id):
+        print "removing mod:", mod_id
+        if mod_id in _modmenu_mods_to_add:
+            _modmenu_mods_to_add.pop(mod_id)
+        else:
+            _modmenu_mods_to_remove.add(mod_id)
+        return
+
+    def _modmenu_get_added_mods():
+        return _modmenu_mods_to_add
+
+    def _modmenu_get_removed_mods():
+        return _modmenu_mods_to_remove
+
+    def _modmenu_is_mod_added(mod_id):
+        return mod_id in _modmenu_mods_to_add
+
+    def _modmenu_is_mod_removed(mod_id):
+        return mod_id in _modmenu_mods_to_remove
+
+
 
 screen modmenu_entrance(use_steam):
     modal True
@@ -521,6 +553,19 @@ screen modmenu_paged(contents, use_steam):
                         ]
                 sensitive (current_page < MAX_PAGE)
 
+        textbutton "Download status Placeholder":
+            background "#0000009B"
+            hover_background "#ffffff9B"
+            xpos 1855
+            ypos 990
+            xanchor 1.0
+            yanchor 1.0
+
+            xsize 425
+            ysize 125
+#             xalign 0.0
+#             yalign 0.0
+            action [Function(print, "added:", _modmenu_get_added_mods(), "\nremoved:", _modmenu_get_removed_mods())]
 
     hbox:
         xpos 65
@@ -734,10 +779,11 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
 
                 null width 350
 
-                if str(modid) in modinfo.get_mod_folders():
+                if (str(modid) in modinfo.get_mod_folders() or _modmenu_is_mod_added(modid)) and not _modmenu_is_mod_removed(modid):
                     textbutton "Uninstall":
                         ycenter 0.5
-                        action [Show("modmenu_remove_confirm_2", modname=name, filename=str(modid)),
+                        action [Function(_modmenu_remove_mod, modid),
+#                         Show("modmenu_remove_confirm_2", modname=name, filename=str(modid)),
                                 Play("audio", "se/sounds/open.ogg")]
                         style "modmenu_content_btn"
                         text_style "modmenu_select_btn_text"
@@ -746,7 +792,8 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
                 else:
                     textbutton "Install":
                         ycenter 0.5
-                        action [Show("modmenu_install_confirm", modid=modid, modname=name, use_steam=use_steam),
+                        action [Function(_modmenu_add_mod, modid, name),
+#                         Show("modmenu_install_confirm", modid=modid, modname=name, use_steam=use_steam),
                                 Play("audio", "se/sounds/open.ogg")]
                         style "modmenu_content_btn"
                         text_style "modmenu_select_btn_text"

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -1039,7 +1039,7 @@ screen modmenu_apply_confirm(use_steam):
                 ycenter 0.5
                 xsize 425
                 ysize 125
-                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall),]
+                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall, show_status_screen=True),]
                 sensitive bool(n_mods_to_install) or bool(n_mods_to_uninstall)
 
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -1026,7 +1026,7 @@ screen modmenu_apply_confirm(use_steam):
                 ycenter 0.5
                 xsize 425
                 ysize 125
-                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall, show_status_screen=True, use_steam=use_steam),]
+                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall, show_status_screen=True, reload_script=True, use_steam=use_steam),]
                 sensitive bool(n_mods_to_install) or bool(n_mods_to_uninstall)
 
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -574,7 +574,22 @@ screen modmenu_paged(contents, use_steam):
         $ n_added_mods = len(_modmenu_get_added_mods())
         $ n_removed_mods = len(_modmenu_get_removed_mods())
 
-        textbutton "Install ([n_added_mods], [n_removed_mods])":
+        if n_added_mods:
+            if n_removed_mods:
+                $ apply_button_prefix = "Apply"
+                $ apply_button_postfix = "(+{}, -{})".format(n_added_mods, n_removed_mods)
+            else:
+                $ apply_button_prefix = "Install"
+                $ apply_button_postfix = "({})".format(n_added_mods)
+        else:
+            if n_removed_mods:
+                $ apply_button_prefix = "Uninstall"
+                $ apply_button_postfix = "({})".format(n_removed_mods)
+            else:
+                $ apply_button_prefix = "No mods selected..."
+                $ apply_button_postfix = ""
+
+        textbutton "[apply_button_prefix] [apply_button_postfix]":
             background "#0000009B"
             hover_background "#ffffff9B"
             insensitive_background "#3f3f3fFF"
@@ -722,7 +737,12 @@ screen modmenu_paged_modlist(contents, use_steam):
                         $ modname = "{size=-10}" + modname + "{/size}"
 
                 if str(modid) in modinfo.get_mod_folders():
-                    $ modname = modname + "\n{size=-5}(Installed){/size}"
+                    $ modname += "\n{size=-5}(Installed"
+                    if _modmenu_is_mod_removed(modid):
+                        $ modname += ", removed"
+                    $ modname += "){/size}"
+                elif _modmenu_is_mod_added(modid):
+                    $ modname += "\n{size=-5}(Added){/size}"
 
                 textbutton "[modname]":
                     style "modmenu_select_btn"
@@ -892,55 +912,65 @@ screen modmenu_apply_confirm(use_steam) tag smallscreen2:
 
                 style "yesnobutton"
 
-        $ _install_mods_text = "mod" if n_mods_to_install == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
-        $ _remove_mods_text = "mod" if n_mods_to_uninstall == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
 
-        label "Are you sure you want to install [n_mods_to_install] [_install_mods_text] and remove [n_mods_to_uninstall] [_remove_mods_text]?":
+        $ _install_remove_text = ""
+        if n_mods_to_install:
+            $ _install_mods_word = "mod" if n_mods_to_install == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
+            $ _install_remove_text += "install {} {}".format(n_mods_to_install, _install_mods_word)
+            if n_mods_to_uninstall:
+                $ _install_remove_text += " and "
+        if n_mods_to_uninstall:
+            $ _remove_mods_word = "mod" if n_mods_to_uninstall == 1 else "mods"
+            $ _install_remove_text += "remove {} {}".format(n_mods_to_uninstall, _remove_mods_word)
+        if not _install_remove_text:
+            $ _install_remove_text = "do nothing? how did you get here!"
+
+        label "Are you sure you want to [_install_remove_text]?":
             style "yesno_prompt"
             text_style "yesno_prompt_text"
 
 
-screen modmenu_remove_confirm_2(modname, filename) tag smallscreen2:
-    modal True
-    python:
-        from modloader.modconfig import remove_mod
-
-    add "image/ui/nvlscreen.png" at zoom_fade_in:
-        xcenter 0.5 ycenter 0.5 size (1921, 1081) xoffset -1 yoffset -1
-
-    window id "modmenu_remove_confirm" at popup2:
-        style "alertwindow"
-
-        if modname == "Core":
-            textbutton "Continue":
-                action [Hide("modmenu_remove_confirm_2", transition=dissolve),
-                        Play("audio", "se/sounds/close.ogg")]
-                        hovered Play("audio", "se/sounds/select.ogg")
-                style "yesnobutton"
-                xalign 0.5
-                yalign 0.8
-
-            label "You cannot remove the Core mod.":
-                style "yesno_prompt"
-
-        else:
-            hbox xalign 0.5 yalign 0.8:
-                spacing 250
-                textbutton "Yes":
-                    action [Hide("modmenu_remove_confirm_2"),
-                            Play("audio", "se/sounds/close.ogg"),
-                            Function(remove_mod, modname, filename),
-#                             lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename),
-                            Show("modmenu_remove")]
-                    style "yesnobutton"
-
-                textbutton "No":
-                    action [Hide("modmenu_remove_confirm_2"),
-                            Play("audio", "se/sounds/close.ogg")]
-                    style "yesnobutton"
-
-            label "Are you sure you want to remove [modname]?":
-                style "yesno_prompt"
+# screen modmenu_remove_confirm_2(modname, filename) tag smallscreen2:
+#     modal True
+#     python:
+#         from modloader.modconfig import remove_mod
+#
+#     add "image/ui/nvlscreen.png" at zoom_fade_in:
+#         xcenter 0.5 ycenter 0.5 size (1921, 1081) xoffset -1 yoffset -1
+#
+#     window id "modmenu_remove_confirm" at popup2:
+#         style "alertwindow"
+#
+#         if modname == "Core":
+#             textbutton "Continue":
+#                 action [Hide("modmenu_remove_confirm_2", transition=dissolve),
+#                         Play("audio", "se/sounds/close.ogg")]
+#                         hovered Play("audio", "se/sounds/select.ogg")
+#                 style "yesnobutton"
+#                 xalign 0.5
+#                 yalign 0.8
+#
+#             label "You cannot remove the Core mod.":
+#                 style "yesno_prompt"
+#
+#         else:
+#             hbox xalign 0.5 yalign 0.8:
+#                 spacing 250
+#                 textbutton "Yes":
+#                     action [Hide("modmenu_remove_confirm_2"),
+#                             Play("audio", "se/sounds/close.ogg"),
+#                             Function(remove_mod, modname, filename),
+# #                             lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename),
+#                             Show("modmenu_remove")]
+#                     style "yesnobutton"
+#
+#                 textbutton "No":
+#                     action [Hide("modmenu_remove_confirm_2"),
+#                             Play("audio", "se/sounds/close.ogg")]
+#                     style "yesnobutton"
+#
+#             label "Are you sure you want to remove [modname]?":
+#                 style "yesno_prompt"
 
 
 screen modmenu_nointernet() tag smallscreen2:

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -98,7 +98,6 @@ init python:
         image_urls = [entry[4] for entry in modlist]
         for url in image_urls:
             mod_image_preloader.load(url)
-        return
 
 
     class ImageURL(Image):
@@ -160,13 +159,11 @@ init python:
         curr_screen_scope = renpy.current_screen().scope
         curr_screen_scope["query"] = value
         search_modlist(value, curr_screen_scope["author_query"])
-        return
 
     def set_author_query(value):
         curr_screen_scope = renpy.current_screen().scope
         curr_screen_scope["author_query"] = value
         search_modlist(curr_screen_scope["query"], value)
-        return
 
 
     def search_modlist(query, author_query=""):
@@ -189,8 +186,6 @@ init python:
         curr_screen_scope["search_order_contents"] = reordered_modlist
         _refresh_modlist_page(page, page_size, reordered_modlist, use_steam)
         renpy.restart_interaction()
-
-        return
 
 
 init -1 python:
@@ -238,7 +233,6 @@ init -1 python:
                                             "Error raised:\n"
                                             + "".join(traceback.format_exception(type(exception), exception, exception.traceback))
                 )
-        return
 
     # Ensure error screens are available, as we may need them
     if not renpy.exports.has_screen("_modlist_errors"):
@@ -273,7 +267,6 @@ init -1 python:
         def set_state(self, state):
             with self._state_lock:
                 self._state = state
-            return
 
         def get_state(self):
             with self._state_lock:
@@ -309,7 +302,6 @@ init -1 python:
                 self.set_state(EntranceStates.INTERNET_FAILED)
 
             self._done_signal.set()
-            return
 
     _dots = 1
     _MAX_DOTS = 3
@@ -326,7 +318,7 @@ init -1 python:
         renpy.hide_screen('modmenu_entrance')
         load_manager.disabled.set()
         renpy.restart_interaction()
-        return
+
 
     _modmenu_entrance_cancelled = False
 
@@ -368,7 +360,6 @@ init -1 python:
 
     def _enter_modmenu(use_steam):
         renpy.show_screen('modmenu_entrance', use_steam=use_steam)
-        return
 
 
 
@@ -380,7 +371,6 @@ init -1 python:
         start, end = _get_slice_lims_from_page(page, page_size)
         renpy.hide_screen('modmenu_paged_modlist')
         renpy.show_screen('modmenu_paged_modlist', contents=modlist[start:end], use_steam=use_steam)
-        return
 
 
     _modmenu_mods_to_add = {} # Mods are Subscribed to once they are added the first time. they are installed on exit if they have not been removed.
@@ -400,7 +390,6 @@ init -1 python:
             _modmenu_mods_to_add[mod_id] = mod_name
         else: # Added, then removed this session
             _modmenu_mods_to_remove.pop(mod_id)
-        return
 
     def _modmenu_remove_mod(mod_id, mod_name="", filename=""):
         print "removing mod:", mod_id, mod_name, filename
@@ -408,15 +397,12 @@ init -1 python:
             _modmenu_mods_to_add.pop(mod_id)
         else:
             _modmenu_mods_to_remove[mod_id] = (mod_name, filename)
-        return
 
     def _modmenu_clear_added_mods():
         _modmenu_mods_to_add.clear()
-        return
 
     def _modmenu_clear_removed_mods():
         _modmenu_mods_to_remove.clear()
-        return
 
     def _modmenu_get_added_mods():
         return _modmenu_mods_to_add

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -384,22 +384,22 @@ init -1 python:
 
 
     _modmenu_mods_to_add = {} # Mods are Subscribed to once they are added the first time. they are installed on exit if they have not been removed.
-    _modmenu_mods_to_remove = set() # Mods are Unsubscribed and deleted on exit. this means that a mod that has been added then removed is deleted like any other removed mod.
+    _modmenu_mods_to_remove = {} # Mods are Unsubscribed and deleted on exit. this means that a mod that has been added then removed is deleted like any other removed mod.
 
     def _modmenu_add_mod(mod_id, mod_name):
         print "adding mod:", mod_id, mod_name
         if mod_id not in _modmenu_mods_to_add and mod_id not in _modmenu_mods_to_remove: # Not added yet, and not an existing mod being reinstated
             _modmenu_mods_to_add[mod_id] = mod_name
         else: # Added, then removed this session
-            _modmenu_mods_to_remove.discard(mod_id)
+            _modmenu_mods_to_remove.pop(mod_id)
         return
 
-    def _modmenu_remove_mod(mod_id):
+    def _modmenu_remove_mod(mod_id, mod_name, filename):
         print "removing mod:", mod_id
         if mod_id in _modmenu_mods_to_add:
             _modmenu_mods_to_add.pop(mod_id)
         else:
-            _modmenu_mods_to_remove.add(mod_id)
+            _modmenu_mods_to_remove[mod_id] = (mod_name, filename)
         return
 
     def _modmenu_clear_added_mods():
@@ -572,8 +572,9 @@ screen modmenu_paged(contents, use_steam):
                 sensitive (current_page < MAX_PAGE)
 
         $ n_added_mods = len(_modmenu_get_added_mods())
+        $ n_removed_mods = len(_modmenu_get_removed_mods())
 
-        textbutton "Install ([n_added_mods])":
+        textbutton "Install ([n_added_mods], [n_removed_mods])":
             background "#0000009B"
             hover_background "#ffffff9B"
             insensitive_background "#3f3f3fFF"
@@ -586,7 +587,7 @@ screen modmenu_paged(contents, use_steam):
             ysize 125
             action [Function(print, "added:", _modmenu_get_added_mods(), "\nremoved:", _modmenu_get_removed_mods()),
                     Show("modmenu_apply_confirm", use_steam=use_steam)]
-            sensitive bool(n_added_mods)
+            sensitive bool(n_added_mods) or bool(n_removed_mods)
 
     hbox:
         xpos 65
@@ -810,7 +811,7 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
                 if (str(modid) in modinfo.get_mod_folders() or _modmenu_is_mod_added(modid)) and not _modmenu_is_mod_removed(modid):
                     textbutton "Uninstall":
                         ycenter 0.5
-                        action [Function(_modmenu_remove_mod, modid),
+                        action [Function(_modmenu_remove_mod, modid, name, str(modid)),
 #                         Show("modmenu_remove_confirm_2", modname=name, filename=str(modid)),
                                 Play("audio", "se/sounds/open.ogg")]
                         style "modmenu_content_btn"
@@ -856,13 +857,14 @@ screen modmenu_apply_confirm(use_steam) tag smallscreen2:
     modal True
     python:
         if use_steam:
+            from modloader.modconfig import apply_mod_changes as apply_mod_changes
             from modloader.modconfig import download_steam_mods as download_mods
         else:
             raise NotImplementedError("Github not yet implemented...")
 #             from modloader.modconfig import download_github_mod as download_mod
 
         mods_to_install = _modmenu_get_added_mods()
-        mods_to_uninstall = _modmenu_get_removed_mods()
+        mods_to_uninstall = {mod_name: filename for mod_name, filename in _modmenu_get_removed_mods().itervalues()}
         n_mods_to_install = len(mods_to_install)
         n_mods_to_uninstall = len(mods_to_uninstall)
 
@@ -879,7 +881,7 @@ screen modmenu_apply_confirm(use_steam) tag smallscreen2:
             textbutton "Yes":
                 action [Hide("modmenu_apply_confirm"),
                         Play("audio", "se/sounds/close.ogg"),
-                        lambda download_mods=download_mods, modmap=mods_to_install: download_mods(modmap)
+                        Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall),
                         ]
 
                 style "yesnobutton"
@@ -890,9 +892,10 @@ screen modmenu_apply_confirm(use_steam) tag smallscreen2:
 
                 style "yesnobutton"
 
-        $ _mods_text = "mod" if n_mods_to_install == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
+        $ _install_mods_text = "mod" if n_mods_to_install == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
+        $ _remove_mods_text = "mod" if n_mods_to_uninstall == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
 
-        label "Are you sure you want to install [n_mods_to_install] [_mods_text]?":
+        label "Are you sure you want to install [n_mods_to_install] [_install_mods_text] and remove [n_mods_to_uninstall] [_remove_mods_text]?":
             style "yesno_prompt"
             text_style "yesno_prompt_text"
 
@@ -926,7 +929,8 @@ screen modmenu_remove_confirm_2(modname, filename) tag smallscreen2:
                 textbutton "Yes":
                     action [Hide("modmenu_remove_confirm_2"),
                             Play("audio", "se/sounds/close.ogg"),
-                            lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename),
+                            Function(remove_mod, modname, filename),
+#                             lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename),
                             Show("modmenu_remove")]
                     style "yesnobutton"
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -880,6 +880,9 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
             xpos 1682
             #yalign 0.95
 
+transform _button_zoom:
+    zoom 40.0 / 54.0
+
 
 screen modmenu_apply_confirm(use_steam):
     modal True
@@ -942,9 +945,23 @@ screen modmenu_apply_confirm(use_steam):
                         xfill True
                         mousewheel "change"
 
-                        for modname in _modmenu_get_added_mods().itervalues():
-                            text modname:
-                                xfill True
+                        for modid, modname in _modmenu_get_added_mods().iteritems():
+                            hbox:
+                                spacing 20
+                                ysize 60
+
+                                imagebutton:
+                                    idle "image/ui/close_idle.png" at _button_zoom
+                                    hover "image/ui/close_hover.png"
+                                    yalign 0.5
+
+                                    action Function(_modmenu_remove_mod, modid, modname, str(modid))
+
+                                text modname:
+                                    if len(modname) > 30:
+                                        size 30
+                                    xfill True
+                                    ysize 60
 
                 vbar value YScrollValue("_mod_add_list"):
                     style "modmenu_select_slider"
@@ -970,9 +987,23 @@ screen modmenu_apply_confirm(use_steam):
                         xfill True
                         mousewheel "change"
 
-                        for modname, _ in _modmenu_get_removed_mods().itervalues():
-                            text modname:
-                                xfill True
+                        for modid, (modname, _) in _modmenu_get_removed_mods().iteritems():
+                            hbox:
+                                spacing 20
+                                ysize 60
+
+                                imagebutton:
+                                    idle "image/ui/close_idle.png" at _button_zoom
+                                    hover "image/ui/close_hover.png"
+                                    yalign 0.5
+
+                                    action Function(_modmenu_add_mod, modid, modname)
+
+                                text modname:
+                                    if len(modname) > 30:
+                                        size 30
+                                    xfill True
+                                    ysize 60
 
                 vbar value YScrollValue("_mod_remove_list"):
                     style "modmenu_select_slider"
@@ -1002,13 +1033,14 @@ screen modmenu_apply_confirm(use_steam):
             textbutton "Apply":
                 background "#0000009B"
                 hover_background "#ffffff9B"
+                insensitive_background "#3f3f3fFF"
 
                 xalign 1.0
                 ycenter 0.5
                 xsize 425
                 ysize 125
-                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall),
-                       ]
+                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall),]
+                sensitive bool(n_mods_to_install) or bool(n_mods_to_uninstall)
 
 
 screen modmenu_nointernet() tag smallscreen2:

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -155,37 +155,144 @@ init python:
     import modmenu_search
     import time
 
-    def set_query(value):
-        curr_screen_scope = renpy.current_screen().scope
-        curr_screen_scope["query"] = value
-        search_modlist(value, curr_screen_scope["author_query"])
+    class ModscreenModlistManager:
+        def __init__(self, modlist, page_size=6, filter_map=None, use_steam=True):
+            """Manages the modscreen's displayed modlist, including paging, searching and filtering.
 
-    def set_author_query(value):
-        curr_screen_scope = renpy.current_screen().scope
-        curr_screen_scope["author_query"] = value
-        search_modlist(curr_screen_scope["query"], value)
+            :param modlist: The base modlist to manage
+            :param page_size: The page size of each mod page
+            :param filter_map: mapping from name (str) to filter func: the initial filter types which are available. if None (default), the initial filter map is empty
+            """
+            if page_size <= 0:
+                raise ValueError("page_size={} must be positive!".format(page_size))
+
+            if filter_map is None:
+                filter_map = {}
+
+            self._base_modlist = modlist
+            self._reordered_modlist = modlist
+            self._filtered_modlist = modlist
+
+            self._current_page = 1
+            self._page_size = page_size
+
+            self._query = ""
+            self._author_query = ""
+
+            self._filter_funcs = filter_map
+            self._filter_activity = {name: None for name in filter_map.iterkeys()}
+
+            self.use_steam = use_steam
+
+        def get_current_page(self):
+            return self._current_page
+
+        def get_page_size(self):
+            return self._page_size
+
+        def get_max_page(self):
+            return int(math.ceil(len(self.get_current_modlist()) / float(self.get_page_size()))) # float is used to force accurate division so the ciel actually does its job
+
+        def get_query(self):
+            return self._query
+
+        def get_author_query(self):
+            return self._author_query
+
+        def is_filter_active(self, name):
+            """Return filter name's activity. see set_filter_active for how filter activity is defined"""
+            return self._filter_activity[name]
+
+        def get_filter_func(self, name):
+            return self._filter_funcs[name]
 
 
-    def search_modlist(query, author_query=""):
-        print "searching with {}, {}".format(query, author_query)
+        def get_base_modlist(self):
+            """Get the base modlist, upon which all paging, searching and filtering is done"""
+            return self._base_modlist
 
-        # As renpy input doesn't allow for additional variables to this method, I've had to resort to this cursed thing
-        curr_screen_scope = renpy.current_screen().scope
-        modlist = curr_screen_scope["contents"]
-        page = curr_screen_scope["current_page"]
-        page_size = curr_screen_scope["PAGE_SIZE"]
-        use_steam = curr_screen_scope["use_steam"]
+        def get_current_modlist(self):
+            """Get the searched and filtered modlist"""
+            return self._filtered_modlist
 
-        s_time = time.time()
-        if query.strip() or author_query.strip(): # There's no reason to reorder the modlist if no search has been done.
-            reordered_modlist = modmenu_search.sort_best(query, modlist, author_query=author_query)
-        else:
-            reordered_modlist = curr_screen_scope["contents"]
-        print "Search took: {:.5}".format(time.time() - s_time) # Hopefully this never goes above 0.3
+        def get_current_modlist_page(self):
+            page_size = self.get_page_size()
+            page = self.get_current_page()
+            return self.get_current_modlist()[page_size*(page - 1) : page_size*page] # Pages are 1-indexed but lists are 0-indexed, so 1 is subtracted from page# to match them
 
-        curr_screen_scope["search_order_contents"] = reordered_modlist
-        _refresh_modlist_page(page, page_size, reordered_modlist, use_steam)
-        renpy.restart_interaction()
+
+        def set_current_page(self, page_num):
+            self._current_page = min(max(page_num, 1), self.get_max_page()) # clamp
+
+        def move_current_page(self, amount):
+            self.set_current_page(self.get_current_page() + amount)
+
+        def set_page_size(self, page_size):
+            if page_size <= 0:
+                raise ValueError("page_size={} must be positive!".format(page_size))
+            self._page_size = page_size
+
+        def set_query(self, query):
+            self._query = query
+            self._apply_search()
+
+        def set_author_query(self, query):
+            self._author_query = query
+            self._apply_search()
+
+        def set_filter_active(self, name, active):
+            """Set activity status of filter of name name
+            :param name: The name in the name map of the filter to set
+            :param active: The activity status to set. True filters out False results, False filters out True results, and None is disabled"""
+            print "setting filter \"{}\" to".format(name), active
+            self._filter_activity[name] = active
+            self._apply_filters()
+
+        def register_filter(self, name, func):
+            """Register a new filter func with the name name
+            :raises KeyError if name is already present"""
+            if name in self._filter_funcs:
+                raise KeyError("\'{}\' is already registered".format(name))
+
+            self._filter_funcs[name] = func
+            self._filter_activity[name] = None
+
+
+        def _apply_search(self):
+            """apply the new search to the modlist"""
+            s_time = time.time()
+            if self._query.strip() or self._author_query.strip(): # There's no reason to reorder the modlist if no search has been done.
+                self._reordered_modlist = modmenu_search.sort_best(self._query, self.get_base_modlist(), author_query=self._author_query)
+            else:
+                self._reordered_modlist = self.get_base_modlist()
+            print "Search took: {:.5}".format(time.time() - s_time) # Hopefully this never goes above 0.3
+            self._apply_filters()
+
+        def _apply_filters(self):
+            result_contents = []
+
+            for entry in self._reordered_modlist:
+                passed = True
+                for name, status in self._filter_activity.iteritems():
+                    if status is not None and self._filter_funcs[name](entry) != status:
+                        passed = False
+                        break
+                if passed:
+                    result_contents.append(entry)
+
+            self._filtered_modlist = result_contents
+#             _refresh_modlist(self, self.use_steam)
+
+    def _modmenu_do_then_refresh(func, modlist_manager, use_steam):
+        """A wrapper which calls func and then refreshes the modlist display. necessary for searchbars, as they don't accept Actions"""
+        def inner(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            finally:
+                _refresh_modlist(modlist_manager, use_steam)
+
+        return inner
+
 
 
 init -1 python:
@@ -363,16 +470,13 @@ init -1 python:
 
 
 
-    # Paging methods
-    def _get_slice_lims_from_page(page, page_size):
-        return page_size * (page - 1), page_size * page # Pages are 1-indexed but lists are 0-indexed, so 1 is subtracted from page# to match them
-
-    def _refresh_modlist_page(page, page_size, modlist, use_steam):
-        start, end = _get_slice_lims_from_page(page, page_size)
+    def _refresh_modlist(modlist_manager, use_steam):
         renpy.hide_screen('modmenu_paged_modlist')
-        renpy.show_screen('modmenu_paged_modlist', contents=modlist[start:end], use_steam=use_steam)
+        renpy.show_screen('modmenu_paged_modlist', contents=modlist_manager.get_current_modlist_page(), use_steam=use_steam)
+        renpy.restart_interaction()
 
 
+    # Mod selection methods
     _modmenu_mods_to_add = {} # Mods are Subscribed to once they are added the first time. they are installed on exit if they have not been removed.
     _modmenu_mods_to_remove = {} # Mods are Unsubscribed and deleted on exit. this means that a mod that has been added then removed is deleted like any other removed mod.
 
@@ -472,14 +576,13 @@ screen modmenu_entrance(use_steam):
 screen modmenu_paged(contents, use_steam):
     modal True
 
-    default current_page = 1
-    default PAGE_SIZE = 6
-    $ MIN_PAGE = 1 # Do note, modpage numbers are 1-indexed
-    $ MAX_PAGE = int(math.ceil(len(contents) / float(PAGE_SIZE)))
+    python:
+        filter_map = {"install": lambda mod: _modmenu_is_mod_installed(mod[0], mod[1]),
+                   "select": lambda mod: _modmenu_is_mod_added(mod[0]) or _modmenu_is_mod_removed(mod[0]),
+                   "present": lambda mod: _modmenu_is_mod_present(mod[0], mod[1]),
+                  }
 
-    default search_order_contents = contents
-    default query = ""
-    default author_query = ""
+    default modlist_manager = ModscreenModlistManager(contents, filter_map=filter_map, use_steam=use_steam)
 
     frame id "modmenu_paged" at alpha_dissolve:
         add "image/ui/ingame_menu_bg3.png"
@@ -528,43 +631,45 @@ screen modmenu_paged(contents, use_steam):
                 xalign 0.2
                 ycenter 0.5
                 # Tried to bind this to shift+scroll, but it didn't work...
-                action [SetScreenVariable("current_page", max(current_page-5, MIN_PAGE)),
-                        Function(_refresh_modlist_page, max(current_page-5, MIN_PAGE), PAGE_SIZE, search_order_contents, use_steam=use_steam)
+                action [Function(modlist_manager.move_current_page, -5),
+                        Function(_refresh_modlist, modlist_manager, use_steam)
                        ]
-                sensitive (current_page > 1)
+                sensitive (modlist_manager.get_current_page() > 1)
 
             textbutton "-":
                 xalign 0.4
                 ycenter 0.5
                 keysym "mousedown_4"
-                action [SetScreenVariable("current_page", current_page-1),
-                        Function(_refresh_modlist_page, current_page-1, PAGE_SIZE, search_order_contents, use_steam=use_steam)
+                action [Function(modlist_manager.move_current_page, -1),
+                        Function(_refresh_modlist, modlist_manager, use_steam)
                        ]
-                sensitive (current_page > 1)
+                sensitive (modlist_manager.get_current_page() > 1)
 
-            label "Page #[current_page]/[MAX_PAGE]":
+            # renpy seems to not like calling things in the string formatting...
+            $ _page_num = modlist_manager.get_current_page()
+            $ _max_page = modlist_manager.get_max_page()
+            label "Page #[_page_num]/[_max_page]":
                 xalign 0.5
                 ycenter 0.5
-
                 text_size 40
 
             textbutton "+":
                 xalign 0.6
                 ycenter 0.5
                 keysym "mousedown_5"
-                action [SetScreenVariable("current_page", current_page+1),
-                        Function(_refresh_modlist_page, current_page+1, PAGE_SIZE, search_order_contents, use_steam=use_steam)
+                action [Function(modlist_manager.move_current_page, 1),
+                        Function(_refresh_modlist, modlist_manager, use_steam)
                         ]
-                sensitive (current_page < MAX_PAGE)
+                sensitive (modlist_manager.get_current_page() < modlist_manager.get_max_page())
 
             textbutton "+5":
                 xalign 0.8
                 ycenter 0.5
                 # Also tried to bind this to shift+scroll, but it didn't work...
-                action [SetScreenVariable("current_page", min(current_page+5, MAX_PAGE)),
-                        Function(_refresh_modlist_page, min(current_page+5, MAX_PAGE), PAGE_SIZE, search_order_contents, use_steam=use_steam)
+                action [Function(modlist_manager.move_current_page, 5),
+                        Function(_refresh_modlist, modlist_manager, use_steam)
                         ]
-                sensitive (current_page < MAX_PAGE)
+                sensitive (modlist_manager.get_current_page() < modlist_manager.get_max_page())
 
         $ n_added_mods = len(_modmenu_get_added_mods())
         $ n_removed_mods = len(_modmenu_get_removed_mods())
@@ -599,6 +704,7 @@ screen modmenu_paged(contents, use_steam):
                     Show("modmenu_apply_confirm", use_steam=use_steam)]
             sensitive bool(n_added_mods) or bool(n_removed_mods)
 
+    # Searchbars
     hbox:
         xpos 65
         ypos 10
@@ -654,7 +760,7 @@ screen modmenu_paged(contents, use_steam):
                     ycenter 0.5
                     size 24
                     pixel_width 320 # While the horizontal space is supposed to be 340, The inputs have a tendency to drop down a row...
-                    changed set_author_query
+                    changed _modmenu_do_then_refresh(modlist_manager.set_author_query, modlist_manager, use_steam)
 
 
             button:
@@ -673,15 +779,76 @@ screen modmenu_paged(contents, use_steam):
                     ycenter 0.5
                     size 24
                     pixel_width 320
-                    changed set_query
+                    changed _modmenu_do_then_refresh(modlist_manager.set_query, modlist_manager, use_steam)
         key "K_ESCAPE" action [SetScreenVariable("focus_query_input", False), SetScreenVariable("focus_author_query_input", False)]
         key "K_TAB" action [ToggleScreenVariable("focus_author_query_input"),
                             If(focus_author_query_input,
                                ToggleScreenVariable("focus_query_input"),
                                SetScreenVariable("focus_query_input", False))]
 
+    # Filter buttons
+    hbox:
+        xpos 510
+        ypos 10
+        xanchor 0.0
+        yanchor 0.0
+        xsize 250
+        ysize 110
 
-    on "show" action [Function(_refresh_modlist_page, current_page, PAGE_SIZE, contents, use_steam=use_steam),
+        spacing 10
+
+        vbox:
+            xalign 0.0
+            ycenter 0.5
+            xsize 200
+            spacing 6
+
+            # For some reason 'label' and 'text' text components insisted on being ever so slightly larger than necessary, which made everything look misaligned
+            textbutton "Installed":
+                background "#00000000"
+                text_size 24
+                ysize 32
+                xalign 0.0
+
+            textbutton "Selected":
+                background "#00000000"
+                text_size 24
+                ysize 32
+                xalign 0.0
+
+            textbutton "To be installed":
+                background "#00000000"
+                text_size 24
+                ysize 32
+                xalign 0.0
+
+        vbox:
+            xalign 1.0
+            ycenter 0.5
+            spacing 6
+
+            $ _im_size = 30
+
+            for filter_name in ["install", "select", "present"]:
+
+                $ _status = modlist_manager.is_filter_active(filter_name)
+                imagebutton:
+                    if _status is True:
+                        idle im.Scale("ui/nsfw_chbox-checked.png", _im_size, _im_size)
+                    elif _status is False:
+                        idle im.Scale("ui/nsfw_chbox-crossed.png", _im_size, _im_size)
+                    else: # _status is None
+                        idle im.Scale("ui/nsfw_chbox-unchecked.png", _im_size, _im_size)
+
+                    action    [Function(modlist_manager.set_filter_active, filter_name, If(_status is True, None, True)),
+                               Function(_refresh_modlist, modlist_manager, use_steam)
+                              ]
+                    alternate [Function(modlist_manager.set_filter_active, filter_name, If(_status is False, None, False)),
+                               Function(_refresh_modlist, modlist_manager, use_steam)
+                              ]
+
+
+    on "show" action [Function(_refresh_modlist, modlist_manager, use_steam),
                       Function(_preload_mod_images, contents, None),
                       Function(im.cache.clear) # I tended to get 'out of memory' errors on this menu, so we use this precaution
                       ]

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -383,15 +383,15 @@ init -1 python:
         return
 
 
-    _modmenu_mods_to_add = {}
-    _modmenu_mods_to_remove = set()
+    _modmenu_mods_to_add = {} # Mods are Subscribed to once they are added the first time. they are installed on exit if they have not been removed.
+    _modmenu_mods_to_remove = set() # Mods are Unsubscribed and deleted on exit. this means that a mod that has been added then removed is deleted like any other removed mod.
 
     def _modmenu_add_mod(mod_id, mod_name):
         print "adding mod:", mod_id, mod_name
-        if mod_id in _modmenu_mods_to_remove:
-            _modmenu_mods_to_remove.discard(mod_id)
-        else:
+        if mod_id not in _modmenu_mods_to_add and mod_id not in _modmenu_mods_to_remove: # Not added yet, and not an existing mod being reinstated
             _modmenu_mods_to_add[mod_id] = mod_name
+        else: # Added, then removed this session
+            _modmenu_mods_to_remove.discard(mod_id)
         return
 
     def _modmenu_remove_mod(mod_id):
@@ -400,6 +400,14 @@ init -1 python:
             _modmenu_mods_to_add.pop(mod_id)
         else:
             _modmenu_mods_to_remove.add(mod_id)
+        return
+
+    def _modmenu_clear_added_mods():
+        _modmenu_mods_to_add.clear()
+        return
+
+    def _modmenu_clear_removed_mods():
+        _modmenu_mods_to_remove.clear()
         return
 
     def _modmenu_get_added_mods():
@@ -413,6 +421,15 @@ init -1 python:
 
     def _modmenu_is_mod_removed(mod_id):
         return mod_id in _modmenu_mods_to_remove
+
+    def _modmenu_get_mod_actions():
+        """Using the add and remove list, get the list of mods to install, and the list of mods to uninstall.
+        This is distinct from the basic getters as the list of mods to install may not contain any mod that should be removed.
+        :returns 2-tuple containing a dict[int: str], and a set[int].
+            the dict is the dict of mods to install, from mod id to modname.
+            the set is the set of mods to uninstall, by mod id."""
+        mods_to_install = {mod_id: mod_name for mod_id, mod_name in _modmenu_mods_to_add.iteritems() if mod_id not in _modmenu_mods_to_remove}
+        return mods_to_install, _modmenu_get_removed_mods()
 
 
 
@@ -494,7 +511,8 @@ screen modmenu_paged(contents, use_steam):
                     Hide("modmenu_entrance", transition=dissolve),
                     Stop("modmenu_music", fadeout=1.0),
                     Play("music", "mx/menu.ogg", fadein=1.0),
-                    Play("audio", "se/sounds/close.ogg")]
+                    Play("audio", "se/sounds/close.ogg")
+                    ]
 
             xpos 0.94
             ypos 0.02
@@ -553,9 +571,12 @@ screen modmenu_paged(contents, use_steam):
                         ]
                 sensitive (current_page < MAX_PAGE)
 
-        textbutton "Download status Placeholder":
+        $ n_added_mods = len(_modmenu_get_added_mods())
+
+        textbutton "Install ([n_added_mods])":
             background "#0000009B"
             hover_background "#ffffff9B"
+            insensitive_background "#3f3f3fFF"
             xpos 1855
             ypos 990
             xanchor 1.0
@@ -563,9 +584,9 @@ screen modmenu_paged(contents, use_steam):
 
             xsize 425
             ysize 125
-#             xalign 0.0
-#             yalign 0.0
-            action [Function(print, "added:", _modmenu_get_added_mods(), "\nremoved:", _modmenu_get_removed_mods())]
+            action [Function(print, "added:", _modmenu_get_added_mods(), "\nremoved:", _modmenu_get_removed_mods()),
+                    Show("modmenu_apply_confirm", use_steam=use_steam)]
+            sensitive bool(n_added_mods)
 
     hbox:
         xpos 65
@@ -657,6 +678,8 @@ screen modmenu_paged(contents, use_steam):
     on "hide" action [Function(mod_image_preloader.clear), # Cleanup after ourselves
                       Function(im.cache.clear),
                       Function(modmenu_search.clear_cache),
+                      Function(_modmenu_clear_added_mods),
+                      Function(_modmenu_clear_removed_mods)
                      ]
 
 
@@ -700,9 +723,14 @@ screen modmenu_paged_modlist(contents, use_steam):
                 if str(modid) in modinfo.get_mod_folders():
                     $ modname = modname + "\n{size=-5}(Installed){/size}"
 
-
                 textbutton "[modname]":
                     style "modmenu_select_btn"
+                    if _modmenu_is_mod_added(modid):
+                        background "#007f009B"
+                        hover_background "#7fff7f9B"
+                    elif _modmenu_is_mod_removed(modid):
+                        background "#7f00009B"
+                        hover_background "#ff7f7f9B"
 
                     action [Hide("modmenu_mod_content"),
                             Show("modmenu_mod_content",
@@ -824,37 +852,47 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
             #yalign 0.95
 
 
-screen modmenu_install_confirm(modid, modname, use_steam) tag smallscreen2:
+screen modmenu_apply_confirm(use_steam) tag smallscreen2:
     modal True
     python:
         if use_steam:
-            from modloader.modconfig import download_steam_mod as download_mod
+            from modloader.modconfig import download_steam_mods as download_mods
         else:
-            from modloader.modconfig import download_github_mod as download_mod
+            raise NotImplementedError("Github not yet implemented...")
+#             from modloader.modconfig import download_github_mod as download_mod
+
+        mods_to_install = _modmenu_get_added_mods()
+        mods_to_uninstall = _modmenu_get_removed_mods()
+        n_mods_to_install = len(mods_to_install)
+        n_mods_to_uninstall = len(mods_to_uninstall)
+
 
     add "image/ui/nvlscreen.png" at zoom_fade_in:
         xcenter 0.5 ycenter 0.5 size (1921, 1081) xoffset -1 yoffset -1
 
-    window id "modmenu_install_confirm" at popup2:
+    window id "modmenu_apply_confirm" at popup2:
         style "alertwindow"
 
         hbox xalign 0.5 yalign 0.8:
             spacing 250
 
             textbutton "Yes":
-                action [Hide("modmenu_install_confirm"),
+                action [Hide("modmenu_apply_confirm"),
                         Play("audio", "se/sounds/close.ogg"),
-                        lambda download_mod=download_mod, modname=modname, modid=modid: download_mod(modid, modname)]
+                        lambda download_mods=download_mods, modmap=mods_to_install: download_mods(modmap)
+                        ]
 
                 style "yesnobutton"
 
             textbutton "No":
-                action [Hide("modmenu_install_confirm", transition=dissolve),
+                action [Hide("modmenu_apply_confirm", transition=dissolve),
                         Play("audio", "se/sounds/close.ogg")]
 
                 style "yesnobutton"
 
-        label "Are you sure you want to install [modname]?":
+        $ _mods_text = "mod" if n_mods_to_install == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
+
+        label "Are you sure you want to install [n_mods_to_install] [_mods_text]?":
             style "yesno_prompt"
             text_style "yesno_prompt_text"
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -386,10 +386,15 @@ init -1 python:
     _modmenu_mods_to_add = {} # Mods are Subscribed to once they are added the first time. they are installed on exit if they have not been removed.
     _modmenu_mods_to_remove = {} # Mods are Unsubscribed and deleted on exit. this means that a mod that has been added then removed is deleted like any other removed mod.
 
-    def _modmenu_is_mod_present(modid):
-        return (str(modid) in modinfo.get_mod_folders() or _modmenu_is_mod_added(modid)) and not _modmenu_is_mod_removed(modid)
+    def _modmenu_is_mod_installed(mod_id, mod_name):
+        """Is mod actually installed on the computer, regardless of modmenu status."""
+        return str(mod_id) in modinfo.get_mod_folders() or str(mod_name) in modinfo.get_mod_folders()
 
-    def _modmenu_add_mod(mod_id, mod_name):
+    def _modmenu_is_mod_present(mod_id, mod_name):
+        """Will the mod be installed once the modmenu changes have been applied."""
+        return (_modmenu_is_mod_installed(mod_id, mod_name) or _modmenu_is_mod_added(mod_id)) and not _modmenu_is_mod_removed(mod_id)
+
+    def _modmenu_add_mod(mod_id, mod_name=""):
         print "adding mod:", mod_id, mod_name
         if mod_id not in _modmenu_mods_to_add and mod_id not in _modmenu_mods_to_remove: # Not added yet, and not an existing mod being reinstated
             _modmenu_mods_to_add[mod_id] = mod_name
@@ -397,8 +402,8 @@ init -1 python:
             _modmenu_mods_to_remove.pop(mod_id)
         return
 
-    def _modmenu_remove_mod(mod_id, mod_name, filename):
-        print "removing mod:", mod_id
+    def _modmenu_remove_mod(mod_id, mod_name="", filename=""):
+        print "removing mod:", mod_id, mod_name, filename
         if mod_id in _modmenu_mods_to_add:
             _modmenu_mods_to_add.pop(mod_id)
         else:
@@ -739,7 +744,7 @@ screen modmenu_paged_modlist(contents, use_steam):
                         $ modname = modname[:30]
                         $ modname = "{size=-10}" + modname + "{/size}"
 
-                if str(modid) in modinfo.get_mod_folders():
+                if _modmenu_is_mod_installed(modid, name):
                     $ modname += "\n{size=-5}(Installed"
                     if _modmenu_is_mod_removed(modid):
                         $ modname += ", removed"
@@ -767,8 +772,8 @@ screen modmenu_paged_modlist(contents, use_steam):
                                  ),
                             Play("audio", "se/sounds/open.ogg")]
 
-                    alternate [If(_modmenu_is_mod_present(modid),
-                                   Function(_modmenu_remove_mod, modid, name, str(modid)),
+                    alternate [If(_modmenu_is_mod_present(modid, name),
+                                   Function(_modmenu_remove_mod, modid, name, If(use_steam, str(modid), name)),
                                    Function(_modmenu_add_mod, modid, name)),
                                Play("audio", "se/sounds/open.ogg")]
                               ]
@@ -836,11 +841,10 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
 
                 null width 350
 
-                if _modmenu_is_mod_present(modid):
+                if _modmenu_is_mod_present(modid, name):
                     textbutton "Uninstall":
                         ycenter 0.5
-                        action [Function(_modmenu_remove_mod, modid, name, str(modid)),
-#                         Show("modmenu_remove_confirm_2", modname=name, filename=str(modid)),
+                        action [Function(_modmenu_remove_mod, modid, name, If(use_steam, str(modid), name)),
                                 Play("audio", "se/sounds/open.ogg")]
                         style "modmenu_content_btn"
                         text_style "modmenu_select_btn_text"
@@ -887,11 +891,7 @@ transform _button_zoom:
 screen modmenu_apply_confirm(use_steam):
     modal True
     python:
-        if use_steam:
-            from modloader.modconfig import apply_mod_changes as apply_mod_changes
-        else:
-            raise NotImplementedError("Github not yet implemented...")
-#             from modloader.modconfig import download_github_mod as download_mod
+        from modloader.modconfig import apply_mod_changes as apply_mod_changes
 
         mods_to_install = _modmenu_get_added_mods()
         mods_to_uninstall = {mod_name: filename for mod_name, filename in _modmenu_get_removed_mods().itervalues()}
@@ -955,7 +955,7 @@ screen modmenu_apply_confirm(use_steam):
                                     hover "image/ui/close_hover.png"
                                     yalign 0.5
 
-                                    action Function(_modmenu_remove_mod, modid, modname, str(modid))
+                                    action Function(_modmenu_remove_mod, modid) # As mod is guaranteed to be in the add list, we only need id to remove.
 
                                 text modname:
                                     if len(modname) > 30:
@@ -997,7 +997,7 @@ screen modmenu_apply_confirm(use_steam):
                                     hover "image/ui/close_hover.png"
                                     yalign 0.5
 
-                                    action Function(_modmenu_add_mod, modid, modname)
+                                    action Function(_modmenu_add_mod, modid) # As mod is guaranteed to be in the remove list, we only need id to add.
 
                                 text modname:
                                     if len(modname) > 30:
@@ -1039,7 +1039,7 @@ screen modmenu_apply_confirm(use_steam):
                 ycenter 0.5
                 xsize 425
                 ysize 125
-                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall, show_status_screen=True),]
+                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall, show_status_screen=True, use_steam=use_steam),]
                 sensitive bool(n_mods_to_install) or bool(n_mods_to_uninstall)
 
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -386,16 +386,17 @@ init -1 python:
 
     def _modmenu_add_mod(mod_id, mod_name=""):
         print "adding mod:", mod_id, mod_name
-        if mod_id not in _modmenu_mods_to_add and mod_id not in _modmenu_mods_to_remove: # Not added yet, and not an existing mod being reinstated
-            _modmenu_mods_to_add[mod_id] = mod_name
-        else: # Added, then removed this session
+        if mod_id in _modmenu_mods_to_remove: # Added, then removed this session
             _modmenu_mods_to_remove.pop(mod_id)
+        elif mod_id not in _modmenu_mods_to_add: # Not added yet, and not an existing mod being reinstated
+            _modmenu_mods_to_add[mod_id] = mod_name
+        # else: nothing to do...
 
     def _modmenu_remove_mod(mod_id, mod_name="", filename=""):
         print "removing mod:", mod_id, mod_name, filename
         if mod_id in _modmenu_mods_to_add:
             _modmenu_mods_to_add.pop(mod_id)
-        else:
+        elif mod_id not in _modmenu_mods_to_remove:
             _modmenu_mods_to_remove[mod_id] = (mod_name, filename)
 
     def _modmenu_clear_added_mods():

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -886,7 +886,7 @@ screen modmenu_apply_confirm(use_steam):
         n_mods_to_uninstall = len(mods_to_uninstall)
 
     window id "modmenu_apply_confirm" at alpha_dissolve:
-        background "image/ui/nvlscreen.png"
+        add "#22589a"
         xfill True
         yfill True
 

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -881,12 +881,11 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
             #yalign 0.95
 
 
-screen modmenu_apply_confirm(use_steam) tag smallscreen2:
+screen modmenu_apply_confirm(use_steam):
     modal True
     python:
         if use_steam:
             from modloader.modconfig import apply_mod_changes as apply_mod_changes
-            from modloader.modconfig import download_steam_mods as download_mods
         else:
             raise NotImplementedError("Github not yet implemented...")
 #             from modloader.modconfig import download_github_mod as download_mod
@@ -896,89 +895,120 @@ screen modmenu_apply_confirm(use_steam) tag smallscreen2:
         n_mods_to_install = len(mods_to_install)
         n_mods_to_uninstall = len(mods_to_uninstall)
 
+    window id "modmenu_apply_confirm" at alpha_dissolve:
+        background "image/ui/nvlscreen.png"
+        xfill True
+        yfill True
 
-    add "image/ui/nvlscreen.png" at zoom_fade_in:
-        xcenter 0.5 ycenter 0.5 size (1921, 1081) xoffset -1 yoffset -1
+        xpadding 0
+        ypadding 0
 
-    window id "modmenu_apply_confirm" at popup2:
-        style "alertwindow"
+        text "Are you sure you want to change these mods?":
+            size 65
+            xpos 0.5
+            ypos 0.05
+            xcenter 0.5
+            yanchor 0.5
+            font "Ardnas.otf"
 
-        hbox xalign 0.5 yalign 0.8:
-            spacing 250
 
-            textbutton "Yes":
-                action [Hide("modmenu_apply_confirm"),
-                        Play("audio", "se/sounds/close.ogg"),
-                        Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall),
-                        ]
+        hbox: # Changelist
+            ysize 700
+            xsize 1800
 
-                style "yesnobutton"
+            ypos 100
+            xcenter 0.5
+            yanchor 0.0
 
-            textbutton "No":
+            $ mods_to_add_text = "\n".join(_modmenu_get_added_mods().itervalues())
+            $ mods_to_remove_text = "\n".join(modname for modname, filename in _modmenu_get_removed_mods().itervalues())
+
+            fixed: # Added mods list: fixed is used to force list+scrollbar to stay within their region
+                xalign 0.0
+                xsize 850
+                ymaximum 700
+
+                vbox:
+                    xsize 800
+                    xalign 0.0
+
+                    text "Added mods:":
+                        size 50
+                        ysize 100
+                        xfill True
+
+                    vpgrid id "_mod_add_list":
+                        cols 1
+                        xfill True
+                        mousewheel "change"
+
+                        for modname in _modmenu_get_added_mods().itervalues():
+                            text modname:
+                                xfill True
+
+                vbar value YScrollValue("_mod_add_list"):
+                    style "modmenu_select_slider"
+                    xalign 1.0
+
+
+            fixed: # Removed mods list: fixed is used to force list+scrollbar to stay within their region
+                xalign 1.0
+                xsize 850
+                ymaximum 700
+
+                vbox:
+                    xsize 800
+                    xalign 0.0
+
+                    text "Removed mods:":
+                        size 50
+                        ysize 100
+                        xfill True
+
+                    vpgrid id "_mod_remove_list":
+                        cols 1
+                        xfill True
+                        mousewheel "change"
+
+                        for modname, _ in _modmenu_get_removed_mods().itervalues():
+                            text modname:
+                                xfill True
+
+                vbar value YScrollValue("_mod_remove_list"):
+                    style "modmenu_select_slider"
+                    xalign 1.0
+
+        hbox: # Apply/Cancel buttons
+            ysize 125
+            xsize 1200
+
+            ypos 990
+            xcenter 0.5
+            yanchor 1.0
+
+
+            textbutton "Cancel":
+                background "#0000009B"
+                hover_background "#ffffff9B"
+
+                xalign 0.0
+                ycenter 0.5
+                xsize 425
+                ysize 125
                 action [Hide("modmenu_apply_confirm", transition=dissolve),
-                        Play("audio", "se/sounds/close.ogg")]
+                    Play("audio", "se/sounds/close.ogg"),
+                    ]
 
-                style "yesnobutton"
+            textbutton "Apply":
+                background "#0000009B"
+                hover_background "#ffffff9B"
 
-
-        $ _install_remove_text = ""
-        if n_mods_to_install:
-            $ _install_mods_word = "mod" if n_mods_to_install == 1 else "mods" # Need to make sure they have singular/plural agreement, right?
-            $ _install_remove_text += "install {} {}".format(n_mods_to_install, _install_mods_word)
-            if n_mods_to_uninstall:
-                $ _install_remove_text += " and "
-        if n_mods_to_uninstall:
-            $ _remove_mods_word = "mod" if n_mods_to_uninstall == 1 else "mods"
-            $ _install_remove_text += "remove {} {}".format(n_mods_to_uninstall, _remove_mods_word)
-        if not _install_remove_text:
-            $ _install_remove_text = "do nothing? how did you get here!"
-
-        label "Are you sure you want to [_install_remove_text]?":
-            style "yesno_prompt"
-            text_style "yesno_prompt_text"
-
-
-# screen modmenu_remove_confirm_2(modname, filename) tag smallscreen2:
-#     modal True
-#     python:
-#         from modloader.modconfig import remove_mod
-#
-#     add "image/ui/nvlscreen.png" at zoom_fade_in:
-#         xcenter 0.5 ycenter 0.5 size (1921, 1081) xoffset -1 yoffset -1
-#
-#     window id "modmenu_remove_confirm" at popup2:
-#         style "alertwindow"
-#
-#         if modname == "Core":
-#             textbutton "Continue":
-#                 action [Hide("modmenu_remove_confirm_2", transition=dissolve),
-#                         Play("audio", "se/sounds/close.ogg")]
-#                         hovered Play("audio", "se/sounds/select.ogg")
-#                 style "yesnobutton"
-#                 xalign 0.5
-#                 yalign 0.8
-#
-#             label "You cannot remove the Core mod.":
-#                 style "yesno_prompt"
-#
-#         else:
-#             hbox xalign 0.5 yalign 0.8:
-#                 spacing 250
-#                 textbutton "Yes":
-#                     action [Hide("modmenu_remove_confirm_2"),
-#                             Play("audio", "se/sounds/close.ogg"),
-#                             Function(remove_mod, modname, filename),
-# #                             lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename),
-#                             Show("modmenu_remove")]
-#                     style "yesnobutton"
-#
-#                 textbutton "No":
-#                     action [Hide("modmenu_remove_confirm_2"),
-#                             Play("audio", "se/sounds/close.ogg")]
-#                     style "yesnobutton"
-#
-#             label "Are you sure you want to remove [modname]?":
-#                 style "yesno_prompt"
+                xalign 1.0
+                ycenter 0.5
+                xsize 425
+                ysize 125
+                action [Function(apply_mod_changes, add_modmap=mods_to_install, remove_modmap=mods_to_uninstall),
+                       ]
 
 
 screen modmenu_nointernet() tag smallscreen2:

--- a/mods/core/download_mods.rpy
+++ b/mods/core/download_mods.rpy
@@ -386,6 +386,9 @@ init -1 python:
     _modmenu_mods_to_add = {} # Mods are Subscribed to once they are added the first time. they are installed on exit if they have not been removed.
     _modmenu_mods_to_remove = {} # Mods are Unsubscribed and deleted on exit. this means that a mod that has been added then removed is deleted like any other removed mod.
 
+    def _modmenu_is_mod_present(modid):
+        return (str(modid) in modinfo.get_mod_folders() or _modmenu_is_mod_added(modid)) and not _modmenu_is_mod_removed(modid)
+
     def _modmenu_add_mod(mod_id, mod_name):
         print "adding mod:", mod_id, mod_name
         if mod_id not in _modmenu_mods_to_add and mod_id not in _modmenu_mods_to_remove: # Not added yet, and not an existing mod being reinstated
@@ -764,6 +767,11 @@ screen modmenu_paged_modlist(contents, use_steam):
                                  ),
                             Play("audio", "se/sounds/open.ogg")]
 
+                    alternate [If(_modmenu_is_mod_present(modid),
+                                   Function(_modmenu_remove_mod, modid, name, str(modid)),
+                                   Function(_modmenu_add_mod, modid, name)),
+                               Play("audio", "se/sounds/open.ogg")]
+                              ]
 
 
 
@@ -828,7 +836,7 @@ screen modmenu_mod_content(modid, name, author, description, url, use_steam):
 
                 null width 350
 
-                if (str(modid) in modinfo.get_mod_folders() or _modmenu_is_mod_added(modid)) and not _modmenu_is_mod_removed(modid):
+                if _modmenu_is_mod_present(modid):
                     textbutton "Uninstall":
                         ycenter 0.5
                         action [Function(_modmenu_remove_mod, modid, name, str(modid)),

--- a/mods/core/remove_mods.rpy
+++ b/mods/core/remove_mods.rpy
@@ -40,7 +40,8 @@ screen modmenu_remove_confirm(modname, filename) tag smallscreen2:
         else:
             hbox xalign 0.5 yalign 0.8:
                 spacing 250
-                textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
+#                 textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
+                textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), Function(remove_mod, modname, filename), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
                 textbutton "No" action [Hide("modmenu_remove_confirm"),  Play("audio", "se/sounds/close.ogg")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
 
             label "Are you sure you want to remove [modname]?":

--- a/mods/core/remove_mods.rpy
+++ b/mods/core/remove_mods.rpy
@@ -29,7 +29,7 @@ screen modmenu_remove_confirm(modname, filename) tag smallscreen2:
         style "alertwindow"
 
         python:
-            from modloader.modconfig import remove_mod
+            from modloader.modconfig import apply_mod_changes
 
         if modname == "Core":
             textbutton "Continue" action [Hide("modmenu_remove_confirm"), Show("modmenu_remove"), Play("audio", "se/sounds/close.ogg")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton" xalign 0.5 yalign 0.8
@@ -41,7 +41,7 @@ screen modmenu_remove_confirm(modname, filename) tag smallscreen2:
             hbox xalign 0.5 yalign 0.8:
                 spacing 250
 #                 textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
-                textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), Function(remove_mod, modname, filename), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
+                textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), Function(apply_mod_changes, add_modmap={}, remove_modmap={modname: filename}, show_status_screen=False, reload_script=True), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
                 textbutton "No" action [Hide("modmenu_remove_confirm"),  Play("audio", "se/sounds/close.ogg")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
 
             label "Are you sure you want to remove [modname]?":

--- a/mods/core/remove_mods.rpy
+++ b/mods/core/remove_mods.rpy
@@ -40,7 +40,6 @@ screen modmenu_remove_confirm(modname, filename) tag smallscreen2:
         else:
             hbox xalign 0.5 yalign 0.8:
                 spacing 250
-#                 textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), lambda remove_mod=remove_mod, modname=modname, filename=filename: remove_mod(modname, filename), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
                 textbutton "Yes" action [Hide("modmenu_remove_confirm"), Play("audio", "se/sounds/close.ogg"), Function(apply_mod_changes, add_modmap={}, remove_modmap={modname: filename}, show_status_screen=False, reload_script=True), Show("modmenu_remove")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
                 textbutton "No" action [Hide("modmenu_remove_confirm"),  Play("audio", "se/sounds/close.ogg")] hovered Play("audio", "se/sounds/select.ogg") style "yesnobutton"
 

--- a/mods/core/stubs.rpy
+++ b/mods/core/stubs.rpy
@@ -52,26 +52,35 @@ init python:
         from steam_workshop.steamhandler import convert_units, get_instance
 
         def _modloader_download_progress(st, at, install_status):
-            mod_id = install_status.get_curr()
-            if mod_id is None:
+            curr = install_status.get_curr()
+            is_removing = install_status.get_phase()
+            if curr is None:
                 return Text("No mod is being installed...",
                              xalign=0.5,
                              yalign=0.5,
                              substitute=False), .1
 
-            steammgr = get_instance()
-            bytes_downloaded, bytes_total = steammgr.GetItemDownloadInfo(mod_id)
-            mod_name = steammgr.GetItemFromID(mod_id)[1]
-            if bytes_downloaded == bytes_total == 0:
-                return  Text("Installing {}...".format(mod_name,
-                                                       convert_units(bytes_downloaded),
-                                                       convert_units(bytes_total)),
-                             xalign=0.5,
-                             yalign=0.5,
-                             substitute=False), .1
-            return Text("Downloading {}: {}/{}".format(mod_name,
-                                                       convert_units(bytes_downloaded),
-                                                       convert_units(bytes_total)),
-                        xalign=0.5,
-                        yalign=0.5,
-                        substitute=False), .1
+            if not is_removing:
+                mod_id = curr
+                steammgr = get_instance()
+                bytes_downloaded, bytes_total = steammgr.GetItemDownloadInfo(mod_id)
+                mod_name = steammgr.GetItemFromID(mod_id)[1]
+                if bytes_downloaded == bytes_total == 0:
+                    return  Text("Installing {}...".format(mod_name,
+                                                           convert_units(bytes_downloaded),
+                                                           convert_units(bytes_total)),
+                                 xalign=0.5,
+                                 yalign=0.5,
+                                 substitute=False), .1
+                return Text("Downloading {}: {}/{}".format(mod_name,
+                                                           convert_units(bytes_downloaded),
+                                                           convert_units(bytes_total)),
+                            xalign=0.5,
+                            yalign=0.5,
+                            substitute=False), .1
+            else:
+                mod_name = curr
+                return Text("Removing {}".format(mod_name),
+                            xalign=0.5,
+                            yalign=0.5,
+                            substitute=False), .1

--- a/mods/core/stubs.rpy
+++ b/mods/core/stubs.rpy
@@ -51,36 +51,44 @@ init python:
     if workshop_enabled:
         from steam_workshop.steamhandler import convert_units, get_instance
 
-        def _modloader_download_progress(st, at, install_status):
-            curr = install_status.get_curr()
-            is_removing = install_status.get_phase()
-            if curr is None:
-                return Text("No mod is being installed...",
+    def _modloader_download_progress(st, at, install_status):
+        curr = install_status.get_curr()
+        is_removing = install_status.get_phase()
+        use_steam = install_status.use_steam()
+        if curr is None:
+            return Text("No mod is being installed...",
+                         xalign=0.5,
+                         yalign=0.5,
+                         substitute=False), .1
+
+        if not is_removing:
+            print use_steam
+            if use_steam:
+                mod_id = curr
+                steammgr = get_instance()
+                mod_name = steammgr.GetItemFromID(mod_id)[1]
+                bytes_downloaded, bytes_total = steammgr.GetItemDownloadInfo(mod_id)
+                no_install_step = False
+            else:
+                mod_name = curr
+                no_install_step = True
+            if not no_install_step and bytes_downloaded == bytes_total == 0:
+                return  Text("Installing {}...".format(mod_name),
                              xalign=0.5,
                              yalign=0.5,
                              substitute=False), .1
-
-            if not is_removing:
-                mod_id = curr
-                steammgr = get_instance()
-                bytes_downloaded, bytes_total = steammgr.GetItemDownloadInfo(mod_id)
-                mod_name = steammgr.GetItemFromID(mod_id)[1]
-                if bytes_downloaded == bytes_total == 0:
-                    return  Text("Installing {}...".format(mod_name,
-                                                           convert_units(bytes_downloaded),
-                                                           convert_units(bytes_total)),
-                                 xalign=0.5,
-                                 yalign=0.5,
-                                 substitute=False), .1
-                return Text("Downloading {}: {}/{}".format(mod_name,
-                                                           convert_units(bytes_downloaded),
-                                                           convert_units(bytes_total)),
-                            xalign=0.5,
-                            yalign=0.5,
-                            substitute=False), .1
+            if use_steam:
+                postfix = ": {}/{}".format(convert_units(bytes_downloaded),
+                                           convert_units(bytes_total))
             else:
-                mod_name = curr
-                return Text("Removing {}".format(mod_name),
-                            xalign=0.5,
-                            yalign=0.5,
-                            substitute=False), .1
+                postfix = ""
+            return Text("Downloading {}{}".format(mod_name, postfix),
+                        xalign=0.5,
+                        yalign=0.5,
+                        substitute=False), .1
+        else:
+            mod_name = curr
+            return Text("Removing {}".format(mod_name),
+                        xalign=0.5,
+                        yalign=0.5,
+                        substitute=False), .1

--- a/mods/core/stubs.rpy
+++ b/mods/core/stubs.rpy
@@ -40,9 +40,9 @@ screen message(text, bg, fg):
     add bg
     text text xalign 0.5 yalign 0.5 color fg
 
-screen _modloader_download_screen(mod_id):
+screen _modloader_download_screen(install_status):
     add "#3485e7"
-    add DynamicDisplayable(_modloader_download_progress, mod_id):
+    add DynamicDisplayable(_modloader_download_progress, install_status):
             xalign 0.5
             yalign 0.5
 
@@ -51,7 +51,14 @@ init python:
     if workshop_enabled:
         from steam_workshop.steamhandler import convert_units, get_instance
 
-        def _modloader_download_progress(st, at, mod_id):
+        def _modloader_download_progress(st, at, install_status):
+            mod_id = install_status.get_curr()
+            if mod_id is None:
+                return Text("No mod is being installed...",
+                             xalign=0.5,
+                             yalign=0.5,
+                             substitute=False), .1
+
             steammgr = get_instance()
             bytes_downloaded, bytes_total = steammgr.GetItemDownloadInfo(mod_id)
             mod_name = steammgr.GetItemFromID(mod_id)[1]


### PR DESCRIPTION
Creates functionality to add and remove multiple mods in a single session of the in-game mod browser, improving usability and saving game restarts.

Mods may be selected for installation/removal by the existing install/uninstall buttons in the mod browser, or toggled by right click on their corresponding button in the mod list.

<img width="2020" height="1194" alt="img_0" src="https://github.com/user-attachments/assets/9a47b57d-2f8b-4f00-8c56-2bb0d94cd2ad" />


The selected mod lists (for addition and removal) are viewable in the new apply status screen, which allows removal of mods from these lists.

<img width="2020" height="1194" alt="img_1" src="https://github.com/user-attachments/assets/22ab57a1-828a-48a8-94d2-868aeded5aca" />

Once applied, all selected mods are either installed or uninstalled, with installations coming first.